### PR TITLE
Use env name as a variable for GCS Terraform resources

### DIFF
--- a/datasets/covid19_tracking/covid19_tracking_dataset.tf
+++ b/datasets/covid19_tracking/covid19_tracking_dataset.tf
@@ -24,22 +24,22 @@ output "bigquery_dataset-covid19_tracking-dataset_id" {
   value = google_bigquery_dataset.covid19_tracking.dataset_id
 }
 
-resource "google_storage_bucket" "covid19_tracking-dev-processing" {
-  name                        = "${var.project_num}-covid19_tracking-dev-processing"
+resource "google_storage_bucket" "covid19_tracking-processing" {
+  name                        = "${var.project_num}-covid19_tracking-${var.env}-processing"
   force_destroy               = true
   uniform_bucket_level_access = true
 }
 
 output "storage_bucket-processing-name" {
-  value = google_storage_bucket.covid19_tracking-dev-processing.name
+  value = google_storage_bucket.covid19_tracking-processing.name
 }
 
-resource "google_storage_bucket" "covid19_tracking-dev-destination" {
-  name                        = "${var.project_num}-covid19_tracking-dev-destination"
+resource "google_storage_bucket" "covid19_tracking-destination" {
+  name                        = "${var.project_num}-covid19_tracking-${var.env}-destination"
   force_destroy               = true
   uniform_bucket_level_access = true
 }
 
 output "storage_bucket-destination-name" {
-  value = google_storage_bucket.covid19_tracking-dev-destination.name
+  value = google_storage_bucket.covid19_tracking-destination.name
 }

--- a/datasets/covid19_tracking/variables.tf
+++ b/datasets/covid19_tracking/variables.tf
@@ -19,4 +19,5 @@ variable "project_id" {}
 variable "project_num" {}
 variable "impersonating_acct" {}
 variable "region" {}
+variable "env" {}
 

--- a/scripts/generate_terraform.py
+++ b/scripts/generate_terraform.py
@@ -153,6 +153,7 @@ def generate_tfvars_file(
         "project_num": project_num,
         "impersonating_acct": impersonating_acct,
         "region": region,
+        "env": env_path.name.replace(".", ""),
     }
 
     contents = apply_substitutions_to_template(

--- a/templates/terraform/google_storage_bucket.tf.jinja2
+++ b/templates/terraform/google_storage_bucket.tf.jinja2
@@ -15,9 +15,8 @@
  */
 
 
-{% set tf_resource_name = [dataset_id, env, name]|join("-") -%}
-resource "google_storage_bucket" "{{ tf_resource_name }}" {
-  name          = "${var.project_num}-{{ dataset_id }}-{{ env }}-{{ name }}"
+resource "google_storage_bucket" "{{ dataset_id }}-{{ name }}" {
+  name          = "${var.project_num}-{{ dataset_id }}-${var.env}-{{ name }}"
   force_destroy = true
   {% if location -%}
     location = "{{ location }}"
@@ -28,5 +27,5 @@ resource "google_storage_bucket" "{{ tf_resource_name }}" {
 }
 
 output "storage_bucket-{{ name }}-name" {
-  value = google_storage_bucket.{{ tf_resource_name }}.name
+  value = google_storage_bucket.{{ dataset_id }}-{{ name }}.name
 }

--- a/templates/terraform/variables.tf.jinja2
+++ b/templates/terraform/variables.tf.jinja2
@@ -19,3 +19,4 @@ variable "project_id" {}
 variable "project_num" {}
 variable "impersonating_acct" {}
 variable "region" {}
+variable "env" {}


### PR DESCRIPTION
## Description

_Note: This PR targets the `c19-screenshots` branch._

The name of the default env (i.e. `dev`) is being committed in GCS Terraform resources:

```hcl
# datasets/covid19_tracking/covid19_tracking_dataset.tf

resource "google_storage_bucket" "covid19_tracking-dev-processing" {
  name = "${var.project_num}-covid19_tracking-dev-processing"  # the word "dev" is committed
  # ...
}

output "storage_bucket-processing-name" {
  value = google_storage_bucket.covid19_tracking-dev-processing.name  # the word "dev" is committed
}
```

The above should instead be

```hcl
# datasets/covid19_tracking/covid19_tracking_dataset.tf

resource "google_storage_bucket" "covid19_tracking-processing" {
  name = "${var.project_num}-covid19_tracking-${var.env}-processing"  # env becomes a specified variable
  # ...
}

output "storage_bucket-processing-name" {
  value = google_storage_bucket.covid19_tracking-${var.env}-processing.name  # env becomes a specified variable
}
```

where contributors should be able to specify their own environment while keeping the repository code free of specific env names such as `dev`.

## Checklist
- [x] Tests pass.
- [x] Linters pass.
- [x] Please merge this PR for me once it is approved.
