### PR TITLE
Minimize `503 DELETE` or `503 POST` on GCS move operation for `state_screenshots`

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.25
+          terraform_version: 0.15.1
       - name: Terraform fmt
         run: terraform fmt -check -recursive
         continue-on-error: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.12.25
+          terraform_version: 0.15.1
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Cloud-native, data pipeline architecture for onboarding datasets to the [Google 
 - Familiarity with [Apache Airflow](https://airflow.apache.org/docs/apache-airflow/1.10.14/concepts.html) (>=v1.10.14)
 - [pipenv](https://pipenv-fork.readthedocs.io/en/latest/install.html#installing-pipenv) for creating similar Python environments via `Pipfile.lock`
 - [gcloud](https://cloud.google.com/sdk/gcloud) command-line tool with Google Cloud Platform credentials configured. Instructions can be found [here](https://cloud.google.com/sdk/docs/initializing).
-- [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) `>=v0.12`
+- [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) `>=v0.15.1`
 - [Google Cloud Composer](https://cloud.google.com/composer/docs/concepts/overview) environment running [Apache Airflow](https://airflow.apache.org/docs/apache-airflow/1.10.14/concepts.html) `v1.10.14,<2.0`. To create a new Cloud Composer environment, see [this guide](https://cloud.google.com/composer/docs/how-to/managing/creating).
 
 # Other Requirements

--- a/datasets/covid19_tracking/state_screenshots/custom/web_scrape_and_generate_csv.py
+++ b/datasets/covid19_tracking/state_screenshots/custom/web_scrape_and_generate_csv.py
@@ -76,7 +76,8 @@ def generate_csv_rows(url: str, gcs_path_prefix: str) -> typing.List[dict]:
 
     rows = []
     current_date = None
-    for tr in tr_tags:
+    # Only get screenshots for the last 30 days
+    for tr in tr_tags[:30]:
         td_date, td_source_type, td_screenshots = tr.find_all("td")
 
         if td_date.text:

--- a/datasets/covid19_tracking/state_screenshots/pipeline.yaml
+++ b/datasets/covid19_tracking/state_screenshots/pipeline.yaml
@@ -68,7 +68,7 @@ dag:
         source_object: "data/covid19_tracking/state_screenshots/run_date={{ ds }}/*"
         destination_bucket: "{{ var.json.covid19_tracking.destination_bucket }}"
         destination_object: "datasets/covid19_tracking/state_screenshots/run_date={{ ds }}/"
-        move_object: True
+        move_object: False
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load the data from Airflow data folder to BigQuery"
@@ -110,17 +110,15 @@ dag:
             mode: "REQUIRED"
             description: "The GCS location where the screenshot or file was copied to"
 
-    - operator: "GoogleCloudStorageToGoogleCloudStorageOperator"
-      description: "Task to archive the screenshots CSV file to the destination bucket"
+    - operator: "GoogleCloudStorageDeleteOperator"
+      description: "Delete downloaded screenshots from the Cloud Composer bucket"
       args:
-        task_id: "archive_data_to_destination_bucket"
-        source_bucket: "{{ var.json.shared.composer_bucket }}"
-        source_object: "data/covid19_tracking/state_screenshots/run_date={{ ds }}/*"
-        destination_bucket: "{{ var.json.covid19_tracking.destination_bucket }}"
-        destination_object: "datasets/covid19_tracking/state_screenshots/run_date={{ ds }}/"
-        move_object: False
+        task_id: "delete_screenshots_from_composer_bucket"
+        bucket_name: "{{ var.json.shared.composer_bucket }}"
+        prefix: "data/covid19_tracking/state_screenshots/run_date={{ ds }}"
 
   graph_paths:
     - "generate_csv_data_from_web_scraping >> download_screenshots"
     - "download_screenshots >> upload_screenshots_to_destination_bucket"
-    - "upload_screenshots_to_destination_bucket >> [load_screenshots_to_bq_table, archive_data_to_destination_bucket]"
+    - "upload_screenshots_to_destination_bucket >> load_screenshots_to_bq_table"
+    - "load_screenshots_to_bq_table >> delete_screenshots_from_composer_bucket"

--- a/samples/pipeline.yaml
+++ b/samples/pipeline.yaml
@@ -187,6 +187,27 @@ dag:
         # See https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
         write_disposition: "WRITE_TRUNCATE"
 
+    - operator: "GoogleCloudStorageDeleteOperator"
+      # Initializes a GCS operator that deletes all specified objects
+
+      # Task description
+      description: "Task to run a GoogleCloudStorageDeleteOperator"
+
+      args:
+        # Arguments supported by this operator:
+        # https://airflow.apache.org/docs/apache-airflow/1.10.14/_api/airflow/contrib/operators/gcs_delete_operator/index.html#airflow.contrib.operators.gcs_delete_operator.GoogleCloudStorageDeleteOperator
+        task_id: "sample_gcs_delete_task"
+
+        # The GCS bucket where the objects to delete are located.
+        bucket_name: "sample_bucket"
+
+        # List of objects to delete. These should be the names of objects in the bucket, not including gs://bucket/.
+        objects: ["path/to/some_object"]
+
+        # Alternatively, you can specify a prefix of objects to delete.
+        # All objects matching this prefix in the bucket will be deleted.
+        prefix: "prefix/to/delete"
+
 
   graph_paths:
     # This is where you specify the relationships (i.e. directed paths/edges)
@@ -197,3 +218,4 @@ dag:
     # https://airflow.apache.org/docs/apache-airflow/stable/tutorial.html#setting-up-dependencies
     - "sample_bash_task >> [sample_gcs_to_bq_task, sample_gcs_to_gcs_task]"
     - "sample_gcs_to_bq_task >> sample_bq_sql_task"
+    - "sample_bq_sql_task >> sample_gcs_delete_task"

--- a/samples/pipeline.yaml
+++ b/samples/pipeline.yaml
@@ -72,7 +72,7 @@ dag:
       # - Run processes using specific packages that support CLI commands
 
       # Task description
-      description: "Run a custom Python script that does "
+      description: "Run a custom Python script"
 
       args:
         # Arguments supported by this operator:
@@ -90,10 +90,10 @@ dag:
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       # Initializes GCS to BQ task for the DAG. This operator is used to load a
-      # CSV file from GCS into a BigQuery table
+      # CSV file from GCS into a BigQuery table.
 
       # Task description
-      description: "Task to load the CSV data to BigQuery table"
+      description: "Task to load CSV data to a BigQuery table"
 
       args:
         # Arguments supported by this operator:
@@ -139,19 +139,24 @@ dag:
       # GCS objects from one location to another.
 
       # Task description
-      description: "Task to archive the screenshots CSV file to the destination bucket"
+      description: "Task to run a GoogleCloudStorageToGoogleCloudStorageOperator"
 
       args:
         # Arguments supported by this operator:
         # https://airflow.apache.org/docs/apache-airflow/1.10.14/_api/airflow/contrib/operators/gcs_to_gcs/index.html#airflow.contrib.operators.gcs_to_gcs.GoogleCloudStorageToGoogleCloudStorageOperator
 
         task_id: "sample_gcs_to_gcs_task"
+
+        # The GCS bucket to copy the object/s from
         source_bucket: "{{ var.json.shared.composer_bucket }}"
 
         # Use a trailing "/*" if you want to copy all objects under that path.
         source_object: "data/DATASET_FOLDER_NAME/PIPELINE_FOLDER_NAME/run_date={{ ds }}/*"
 
+        # The GCS bucket to copy the object/s to
         destination_bucket: "{{ var.json.DATASET_FOLDER_NAME.destination_bucket }}"
+
+        # The GCS prefix to copy the object/s to
         destination_object: "datasets/DATASET_FOLDER_NAME/PIPELINE_FOLDER_NAME/run_date={{ ds }}/"
 
         # Use this argument if you don't want to keep the source object/s.
@@ -162,7 +167,7 @@ dag:
       # BigQuery table.
 
       # Task description
-      description: "Task to archive the screenshots CSV file to the destination bucket"
+      description: "Task to run a BigQueryOperator"
 
       args:
         # Arguments supported by this operator:

--- a/scripts/dag_imports.json
+++ b/scripts/dag_imports.json
@@ -19,6 +19,10 @@
         "KubernetesPodOperator": {
             "import": "from airflow.contrib.operators import kubernetes_pod_operator",
             "class": "kubernetes_pod_operator.KubernetesPodOperator"
+        },
+        "GoogleCloudStorageDeleteOperator": {
+            "import": "from airflow.contrib.operators import gcs_delete_operator",
+            "class": "gcs_delete_operator.GoogleCloudStorageDeleteOperator"
         }
     }
 }

--- a/scripts/generate_dag.py
+++ b/scripts/generate_dag.py
@@ -30,6 +30,7 @@ OPERATORS = {
     "BashOperator",
     "GoogleCloudStorageToBigQueryOperator",
     "GoogleCloudStorageToGoogleCloudStorageOperator",
+    "GoogleCloudStorageDeleteOperator",
     "BigQueryOperator",
     "KubernetesPodOperator",
 }


### PR DESCRIPTION
## Description

I occassionally get a `503 DELETE: Backend error` or `503 POST: Backend error` when moving screenshots from the Cloud Composer bucket to the final (public) destination bucket. 

I noticed that the `GoogleCloudStorageToGoogleCloudStorageOperator` does the move operation by individually copying and deleting every object. If there are tens of thousands of objects (about ~50k screenshots) to copy and delete, it's more probable to get that occassional failure.

This PR should help protect us better by decomposing the move operation into a two-step process:

1. Use `GoogleCloudStorageToGoogleCloudStorageOperator` to copy all screenshots to the destination bucket with `move_object=False` (skip the deletes).
2. Use a `GoogleCloudStorageDeleteOperator` to bulk delete all screenshots from the Cloud Composer bucket.

## Checklist
- [x] Tests pass.
- [x] Linters pass.
- [x] Please merge this PR for me once it is approved.
- [x] If this PR adds/edits/deletes a feature, I have updated the [`README`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/blob/main/README.md) or any samples accordingly.
- [x] If this PR adds/edits a new dataset or pipeline, I put all my code inside  `datasets/<YOUR-DATASET>` and nothing outside of that directory.
