### PR TITLE
feat: Support Terraform remote state when generating GCP resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ $ python scripts/generate_terraform.py \
     --region REGION \
     --bucket-name-prefix UNIQUE_BUCKET_PREFIX \
     [--env] dev \
+    [--tf-state-bucket] \
+    [--tf-state-prefix] \
     [--tf-apply] \
     [--impersonating-acct] IMPERSONATING_SERVICE_ACCT
 ```
@@ -88,6 +90,8 @@ $ python scripts/generate_terraform.py \
 This generates Terraform files (`*.tf`) in a `_terraform` directory inside that dataset. The files contain instrastructure-as-code on which GCP resources need to be actuated for use by the pipelines. If you passed in the `--tf-apply` parameter, the command will also run `terraform apply` to actuate those resources.
 
 The `--bucket-name-prefix` is used to ensure that the buckets created by different environments and contributors are kept unique. This is to satisfy the rule where bucket names must be globally unique across all of GCS. Use hyphenated names (`some-prefix-123`) instead of snakecase or underscores (`some_prefix_123`).
+
+The `--tf-state-bucket` and `--tf-state-prefix` parameters can be optionally used if one needs to use a remote store for the Terraform state. This will create a `backend.tf` file that points to the GCS bucket and prefix to use in storing the Terraform state. For more info, see the [Terraform docs for using GCS backends](https://www.terraform.io/docs/language/settings/backends/gcs.html).
 
 In addition, the command above creates a "dot" directory in the project root. The directory name is the value you pass to the `--env` parameter of the command. If no `--env` argument was passed, the value defaults to `dev` (which generates the `.dev` folder).
 

--- a/datasets/ml_datasets/_terraform/ml_datasets_dataset.tf
+++ b/datasets/ml_datasets/_terraform/ml_datasets_dataset.tf
@@ -18,7 +18,7 @@
 resource "google_bigquery_dataset" "ml_datasets" {
   dataset_id = "ml_datasets"
   project    = var.project_id
-  }
+}
 
 output "bigquery_dataset-ml_datasets-dataset_id" {
   value = google_bigquery_dataset.ml_datasets.dataset_id

--- a/datasets/ml_datasets/_terraform/penguins_pipeline.tf
+++ b/datasets/ml_datasets/_terraform/penguins_pipeline.tf
@@ -20,7 +20,7 @@ resource "google_bigquery_table" "penguins" {
   dataset_id = "ml_datasets"
   table_id   = "penguins"
 
-  
+
 
   depends_on = [
     google_bigquery_dataset.ml_datasets

--- a/datasets/ml_datasets/_terraform/provider.tf
+++ b/datasets/ml_datasets/_terraform/provider.tf
@@ -16,9 +16,10 @@
 
 
 provider "google" {
-  project = var.project_id
-  region  = var.region
-  }
+  project                     = var.project_id
+  impersonate_service_account = var.impersonating_acct
+  region                      = var.region
+}
 
 data "google_client_openid_userinfo" "me" {}
 

--- a/datasets/ml_datasets/_terraform/variables.tf
+++ b/datasets/ml_datasets/_terraform/variables.tf
@@ -16,7 +16,7 @@
 
 
 variable "project_id" {}
-variable "project_num" {}
+variable "bucket_name_prefix" {}
 variable "impersonating_acct" {}
 variable "region" {}
 variable "env" {}

--- a/scripts/generate_terraform.py
+++ b/scripts/generate_terraform.py
@@ -35,6 +35,7 @@ TEMPLATE_PATHS = {
     "tfvars": TEMPLATES_PATH / "terraform.tfvars.jinja2",
     "variables": TEMPLATES_PATH / "variables.tf.jinja2",
     "provider": TEMPLATES_PATH / "provider.tf.jinja2",
+    "backend": TEMPLATES_PATH / "backend.tf.jinja2",
 }
 
 yaml = yaml.YAML(typ="safe")

--- a/templates/terraform/backend.tf.jinja2
+++ b/templates/terraform/backend.tf.jinja2
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+terraform {
+  backend "gcs" {
+    bucket = {{ tf_state_bucket }}
+    prefix = {{ tf_state_prefix }}
+  }
+}

--- a/templates/terraform/backend.tf.jinja2
+++ b/templates/terraform/backend.tf.jinja2
@@ -17,7 +17,7 @@
 
 terraform {
   backend "gcs" {
-    bucket = {{ tf_state_bucket }}
-    prefix = {{ tf_state_prefix }}
+    bucket = "{{ tf_state_bucket }}"
+    prefix = "{{ tf_state_prefix }}"
   }
 }


### PR DESCRIPTION
## Description

Based on #33. We need to optionally support Terraform remote state configuration via a `backend.tf` file that's auto-generated. It contains the following:

```hcl
terraform {
  backend "gcs" {
    bucket = "REMOTE_STATE_BUCKET"
    prefix = "REMOTE_STATE_PREFIX"
  }
}
```

This allows users to store a file on GCS representing a record of the GCP resources that Terraform keeps track of for their pipelines.

It's now possible to do this via the `--tf-state-bucket` and `--tf-state-prefix` arguments for `scripts/generate_terraform.py`.

Because backend states differ per user per environment, we only create the `backend.tf` file in the env folder specified, e.g. `.dev/datasets/ml_datasets/_terraform/backend.tf`. That is, we don't check in Terraform remote state files in the repo to keep it optional for everyone.

## Checklist
- [x] Tests pass.
- [x] Linters pass.
- [x] Please merge this PR for me once it is approved.
- [x] If this PR adds/edits/deletes a feature, I have updated the [`README`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/blob/main/README.md) accordingly.