### PR TITLE
fix: Fix renovatebot config based on #43

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,7 @@
   "packageRules": [
     {
       "matchPackageNames": ["apache-airflow"],
-      "allowedVersions": ">=1.10.14,<2.0",
-      "matchUpdateTypes": ["patch"]
+      "allowedVersions": ">=1.10.14,<2.0"
     },
     {
       "matchPackageNames": ["python"],


### PR DESCRIPTION
## Description

Based on #43. I removed the `matchUpdateTypes` field because the version spec already limits `apache-airflow` to `">=1.10.14,<2.0"`.

## Checklist
- [x] Please merge this PR for me once it is approved.
