### PR TITLE
Fix: Terraform resource names can't start with digits, but BQ tables can

### DIFF
--- a/scripts/generate_terraform.py
+++ b/scripts/generate_terraform.py
@@ -203,6 +203,14 @@ def customize_template_subs(resource: dict, subs: dict) -> dict:
         subs["uniform_bucket_level_access"] = resource.get(
             "uniform_bucket_level_access"
         )
+    elif resource["type"] == "bigquery_table":
+        # Terraform resource names cannot start with digits, but BigQuery allows
+        # table names that start with digits. We prepend `bqt_` to table names
+        # that doesn't comply with Terraform's naming rule.
+        if resource["table_id"][0].isdigit():
+            subs["tf_resource_name"] = "bqt_" + resource["table_id"]
+        else:
+            subs["tf_resource_name"] = resource["table_id"]
     return subs
 
 

--- a/templates/terraform/google_bigquery_table.tf.jinja2
+++ b/templates/terraform/google_bigquery_table.tf.jinja2
@@ -15,7 +15,7 @@
  */
 
 
-resource "google_bigquery_table" "{{ table_id }}" {
+resource "google_bigquery_table" "{{ tf_resource_name }}" {
   project    = var.project_id
   dataset_id = "{{ dataset_id }}"
   table_id   = "{{ table_id }}"
@@ -34,9 +34,9 @@ resource "google_bigquery_table" "{{ table_id }}" {
 }
 
 output "bigquery_table-{{ table_id }}-table_id" {
-  value = google_bigquery_table.{{ table_id }}.table_id
+  value = google_bigquery_table.{{ tf_resource_name }}.table_id
 }
 
 output "bigquery_table-{{ table_id }}-id" {
-  value = google_bigquery_table.{{ table_id }}.id
+  value = google_bigquery_table.{{ tf_resource_name }}.id
 }


### PR DESCRIPTION
## Description

Terraform resource names cannot start with digits, but BigQuery allows table names that start with digits. This means that upon `terraform apply`, Terraform will error out despite the BQ table name being valid for Google Cloud.

This PR prepends `bqt_` to Terraform resource names for BigQuery tables that start with digits. If you have a BQ table that's named like `311_austin`, then the following Terraform resource will be generated:

```hcl
resource "google_bigquery_table" "bqt_311_austin" {
  table_id = "311_austin"
}
```

## Checklist

- [ ] This PR is appropriately labeled.
