### PR TITLE
fix: Fix BigQuery dataset descriptions for `covid19_tracking` and `ml_datasets` 

### DIFF
--- a/datasets/covid19_tracking/_terraform/covid19_tracking_dataset.tf
+++ b/datasets/covid19_tracking/_terraform/covid19_tracking_dataset.tf
@@ -16,8 +16,9 @@
 
 
 resource "google_bigquery_dataset" "covid19_tracking" {
-  dataset_id = "covid19_tracking"
-  project    = var.project_id
+  dataset_id  = "covid19_tracking"
+  project     = var.project_id
+  description = "BigQuery dataset for the COVID-19 Tracking Project"
 }
 
 output "bigquery_dataset-covid19_tracking-dataset_id" {

--- a/datasets/covid19_tracking/dataset.yaml
+++ b/datasets/covid19_tracking/dataset.yaml
@@ -28,7 +28,7 @@ resources:
   # Optional: friendly_name, description, location
   - type: bigquery_dataset
     dataset_id: covid19_tracking
-    description: BigQuery dataset to namespace all tables related to COVID-19
+    description: BigQuery dataset for the COVID-19 Tracking Project
 
   - type: storage_bucket
     name: "covid-tracking-project"

--- a/datasets/ml_datasets/dataset.yaml
+++ b/datasets/ml_datasets/dataset.yaml
@@ -54,4 +54,4 @@ resources:
     #   description   (A user-friendly description of the dataset)
     #   location      (The geographic location where the dataset should reside)
     dataset_id: ml_datasets
-    description: "A tabular dataset of penguin measurements alongside species and habitat information. Data were collected and made available by Dr. Kristen Gorman and the Palmer Station, Antarctica LTER, a member of the Long Term Ecological Research Network. It is provided under the Creative Commons Zero v1.0 Universal license. For more details, see: https://github.com/allisonhorst/palmerpenguins"
+    description: ~


### PR DESCRIPTION
## Description

Because #61 allows BQ dataset descriptions to now be generated. I reran and revised the BQ dataset descriptions for `covid19_tracking` and `ml_datasets`.

## Checklist

- [x] Please merge this PR for me once it is approved.
- [x] This PR is appropriately labeled.
