### PR TITLE
feat: Support BigQueryToBigQueryOperator

### DIFF
--- a/samples/pipeline.yaml
+++ b/samples/pipeline.yaml
@@ -278,6 +278,16 @@ dag:
           limit_memory: "250M"
           limit_cpu: "1"
 
+    - operator: "BigQueryToBigQueryOperator"
+      description: "Task to run a BQ to BQ operator"
+
+      args:
+        task_id: "sample_bq_to_bq_task"
+        source_project_dataset_tables: ["{{ var.json.DATASET_FOLDER_NAME.PIPELINE_NAME.source_project_dataset_table }}"]
+        destination_project_dataset_table: "{{ var.json.DATASET_FOLDER_NAME.PIPELINE_NAME.destination_project_dataset_table }}"
+        impersonation_chain: "{{ var.json.DATASET_FOLDER_NAME.service_account }}"
+        write_disposition: "WRITE_TRUNCATE"
+
   graph_paths:
     # This is where you specify the relationships (i.e. directed paths/edges)
     # among the tasks specified above. Use the bitshift operator to define the
@@ -286,5 +296,5 @@ dag:
     # For more info, see
     # https://airflow.apache.org/docs/apache-airflow/stable/tutorial.html#setting-up-dependencies
     - "sample_bash_task >> [sample_gcs_to_bq_task, sample_gcs_to_gcs_task]"
-    - "sample_gcs_to_bq_task >> sample_bq_sql_task"
+    - "sample_gcs_to_bq_task >> [sample_bq_sql_task, sample_bq_to_bq_task]"
     - "sample_bq_sql_task >> sample_gcs_delete_task"

--- a/scripts/dag_imports.json
+++ b/scripts/dag_imports.json
@@ -16,6 +16,10 @@
             "import": "from airflow.contrib.operators import bigquery_operator",
             "class": "bigquery_operator.BigQueryOperator"
         },
+        "BigQueryToBigQueryOperator": {
+            "import": "from airflow.contrib.operators import bigquery_to_bigquery",
+            "class": "bigquery_to_bigquery.BigQueryToBigQueryOperator"
+        },
         "KubernetesPodOperator": {
             "import": "from airflow.contrib.operators import kubernetes_pod_operator",
             "class": "kubernetes_pod_operator.KubernetesPodOperator"

--- a/scripts/generate_dag.py
+++ b/scripts/generate_dag.py
@@ -33,6 +33,7 @@ OPERATORS = {
     "GoogleCloudStorageToGoogleCloudStorageOperator",
     "GoogleCloudStorageDeleteOperator",
     "BigQueryOperator",
+    "BigQueryToBigQueryOperator",
     "KubernetesPodOperator",
 }
 


### PR DESCRIPTION
## Description

Some upcoming datasets are directly fetched from another BQ table with no transforms or schema changes needed. This PR add support for the `BigQueryToBigQueryOperator`.

## Checklist

Note: Delete items below that aren't applicable to your pull request.

- [x] Please merge this PR for me once it is approved.
- [x] If this PR adds or edits a feature, I have updated the [`README`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/blob/main/README.md) accordingly.
- [x] This PR is appropriately labeled.
