### PR TITLE
feat: Ignore changes to `last_modified_time` in Terraform states for BQ tables

### DIFF
--- a/templates/terraform/google_bigquery_dataset.tf.jinja2
+++ b/templates/terraform/google_bigquery_dataset.tf.jinja2
@@ -27,6 +27,13 @@ resource "google_bigquery_dataset" "{{ dataset_id }}" {
   {% if location -%}
     location = "{{ location }}"
   {% endif -%}
+
+  lifecycle {
+    ignore_changes = [
+      access,
+      last_modified_time
+    ]
+  }
 }
 
 output "bigquery_dataset-{{ dataset_id }}-dataset_id" {

--- a/templates/terraform/google_bigquery_dataset.tf.jinja2
+++ b/templates/terraform/google_bigquery_dataset.tf.jinja2
@@ -30,7 +30,6 @@ resource "google_bigquery_dataset" "{{ dataset_id }}" {
 
   lifecycle {
     ignore_changes = [
-      access,
       last_modified_time
     ]
   }


### PR DESCRIPTION
## Description

Some properties for Terraform resources can be safely ignored, so that the remote states doesn't keep changing during deploys. That is, it only stores properties that it expects not to change over time.

One property is the `last_modified_time` for BigQuery datasets. 

## Checklist

- [ ] Please merge this PR for me once it is approved.
- [x] This PR is appropriately labeled.
