### PR TITLE
fix: Allow newline and quotes for BQ dataset and table descriptions

### DIFF
--- a/templates/terraform/google_bigquery_dataset.tf.jinja2
+++ b/templates/terraform/google_bigquery_dataset.tf.jinja2
@@ -22,7 +22,7 @@ resource "google_bigquery_dataset" "{{ dataset_id }}" {
     friendly_name = "{{ friendly_name }}"
   {% endif -%}
   {% if description -%}
-    description = "{{ description }}"
+    description = {{ description|tojson }}
   {% endif -%}
   {% if location -%}
     location = "{{ location }}"

--- a/templates/terraform/google_bigquery_table.tf.jinja2
+++ b/templates/terraform/google_bigquery_table.tf.jinja2
@@ -21,7 +21,7 @@ resource "google_bigquery_table" "{{ tf_resource_name }}" {
   table_id   = "{{ table_id }}"
 
   {% if description -%}
-    description = "{{ description }}"
+    description = {{ description|tojson }}
   {%- endif %}
   {% if schema -%}
     schema = <<EOF


### PR DESCRIPTION
## Description

As per an internal Friction Friday session where newlines in BQ datasets and descriptions resulted in Terraform complaining about the format. 

The `tojson` method in jinja templates preserves escaped characters such as newlines and quotes.

## Checklist

Note: Delete items below that aren't applicable to your pull request.

- [x] Please merge this PR for me once it is approved.
- [x] This PR is appropriately labeled.
