### PR TITLE
docs: Add image_pull_policy for kpod operator sample

### DIFF
--- a/samples/pipeline.yaml
+++ b/samples/pipeline.yaml
@@ -268,6 +268,9 @@ dag:
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.
         image: "{{ var.json.DATASET_FOLDER_NAME.container_registry.IMAGE_REPOSITORY }}"
 
+        # Always pull the latest image. We recommend to keep this as "Always".
+        image_pull_policy: "Always"
+
         # Set the environment variables you need initialized in the container. Use these as input variables for the script your container is expected to perform.
         env_vars:
           TEST_ENV_VAR: "test-value"


### PR DESCRIPTION
## Description

Helps prevent an issue where containerized tasks keep using old images despite new image versions already available.

## Checklist

- [x] Please merge this PR for me once it is approved.
- [x] This PR is appropriately labeled.
