### PR TITLE
cleanup: Partition Google Trends tables

### DIFF
--- a/datasets/google_trends/_terraform/top_terms_pipeline.tf
+++ b/datasets/google_trends/_terraform/top_terms_pipeline.tf
@@ -21,7 +21,47 @@ resource "google_bigquery_table" "top_terms" {
   table_id   = "top_terms"
 
   description = "Daily top 25 terms in the United States with score, ranking, time, and designated market area"
+  time_partitioning {
+    type = "DAY"
 
+    field = "refresh_date"
+
+    require_partition_filter = false
+  }
+
+
+  schema = <<EOF
+    [
+  {
+    "name": "rank",
+    "type": "INTEGER"
+  },
+  {
+    "name": "refresh_date",
+    "type": "DATE"
+  },
+  {
+    "name": "dma_name",
+    "type": "STRING"
+  },
+  {
+    "name": "dma_id",
+    "type": "INTEGER"
+  },
+  {
+    "name": "term",
+    "type": "STRING"
+  },
+  {
+    "name": "week",
+    "type": "DATE"
+  },
+  {
+    "name": "score",
+    "type": "INTEGER"
+  }
+]
+    EOF
   depends_on = [
     google_bigquery_dataset.google_trends
   ]
@@ -41,7 +81,47 @@ resource "google_bigquery_table" "top_rising_terms" {
   table_id   = "top_rising_terms"
 
   description = "Daily top rising terms in the United States with score, ranking, time, and designated market area"
+  time_partitioning {
+    type = "DAY"
 
+    field = "refresh_date"
+
+    require_partition_filter = false
+  }
+
+
+  schema = <<EOF
+    [
+  {
+    "name": "rank",
+    "type": "INTEGER"
+  },
+  {
+    "name": "refresh_date",
+    "type": "DATE"
+  },
+  {
+    "name": "dma_name",
+    "type": "STRING"
+  },
+  {
+    "name": "dma_id",
+    "type": "INTEGER"
+  },
+  {
+    "name": "term",
+    "type": "STRING"
+  },
+  {
+    "name": "week",
+    "type": "DATE"
+  },
+  {
+    "name": "score",
+    "type": "INTEGER"
+  }
+]
+    EOF
   depends_on = [
     google_bigquery_dataset.google_trends
   ]

--- a/datasets/google_trends/top_terms/pipeline.yaml
+++ b/datasets/google_trends/top_terms/pipeline.yaml
@@ -17,10 +17,80 @@ resources:
   - type: bigquery_table
     table_id: top_terms
     description: "Daily top 25 terms in the United States with score, ranking, time, and designated market area"
+    time_partitioning:
+      type: "DAY"
+      field: "refresh_date"
+      require_partition_filter: false
+    schema: |-
+      [
+        {
+          "name": "rank",
+          "type": "INTEGER"
+        },
+        {
+          "name": "refresh_date",
+          "type": "DATE"
+        },
+        {
+          "name": "dma_name",
+          "type": "STRING"
+        },
+        {
+          "name": "dma_id",
+          "type": "INTEGER"
+        },
+        {
+          "name": "term",
+          "type": "STRING"
+        },
+        {
+          "name": "week",
+          "type": "DATE"
+        },
+        {
+          "name": "score",
+          "type": "INTEGER"
+        }
+      ]
 
   - type: bigquery_table
     table_id: top_rising_terms
     description: "Daily top rising terms in the United States with score, ranking, time, and designated market area"
+    time_partitioning:
+      type: "DAY"
+      field: "refresh_date"
+      require_partition_filter: false
+    schema: |-
+      [
+        {
+          "name": "rank",
+          "type": "INTEGER"
+        },
+        {
+          "name": "refresh_date",
+          "type": "DATE"
+        },
+        {
+          "name": "dma_name",
+          "type": "STRING"
+        },
+        {
+          "name": "dma_id",
+          "type": "INTEGER"
+        },
+        {
+          "name": "term",
+          "type": "STRING"
+        },
+        {
+          "name": "week",
+          "type": "DATE"
+        },
+        {
+          "name": "score",
+          "type": "INTEGER"
+        }
+      ]
 
 dag:
   initialize:


### PR DESCRIPTION
## Description

As requested by the Trends team. Note that this is based out of (and targets) the `partitioned-bq-tables` branch which requires that feature.

## Checklist

- [x] Please merge this PR for me once it is approved.
- [x] If this PR adds or edits a dataset or pipeline, it was reviewed and approved by the Google Cloud Public Datasets team beforehand.
- [x] If this PR adds or edits a dataset or pipeline, I put all my code inside  `datasets/<YOUR-DATASET>` and nothing outside of that directory.
- [x] This PR is appropriately labeled.
