### PR TITLE
fix: `shared_variables.json` should not be reset when deploying

### DIFF
--- a/scripts/generate_dag.py
+++ b/scripts/generate_dag.py
@@ -138,8 +138,9 @@ def generate_shared_variables_file(env: str) -> None:
     shared_variables_file = pathlib.Path(
         PROJECT_ROOT / f".{env}" / "datasets" / "shared_variables.json"
     )
-    shared_variables_file.touch()
-    shared_variables_file.write_text("{}", encoding="utf-8")
+    if not shared_variables_file.exists():
+        shared_variables_file.touch()
+        shared_variables_file.write_text("{}", encoding="utf-8")
 
 
 def dag_init(config: dict) -> dict:


### PR DESCRIPTION
## Description

The `shared_variables.json` file introduced by #122 gets reset to an empty JSON object during a deploy. This PR fixes that.

## Checklist

- [ ] Please merge this PR for me once it is approved.
- [ ] If this PR adds or edits a feature, I have updated the [`README`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/blob/main/README.md) accordingly.
- [ ] This PR is appropriately labeled.
