### PR TITLE
chore: Adds node pool affinities for pipelines using KubernetesPodOperator

### DIFF
--- a/datasets/austin_bikeshare/bikeshare_stations/bikeshare_stations_dag.py
+++ b/datasets/austin_bikeshare/bikeshare_stations/bikeshare_stations_dag.py
@@ -37,6 +37,23 @@ with DAG(
         task_id="austin_bikeshare_stations_transform_csv",
         name="bikeshare_stations",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.austin_bikeshare.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/austin_bikeshare/bikeshare_stations/pipeline.yaml
+++ b/datasets/austin_bikeshare/bikeshare_stations/pipeline.yaml
@@ -53,6 +53,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/covid19_italy/data_by_province/data_by_province_dag.py
+++ b/datasets/covid19_italy/data_by_province/data_by_province_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="covid19_italy_data_by_province",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.covid19_italy.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/covid19_italy/data_by_province/pipeline.yaml
+++ b/datasets/covid19_italy/data_by_province/pipeline.yaml
@@ -58,6 +58,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/covid19_italy/data_by_region/data_by_region_dag.py
+++ b/datasets/covid19_italy/data_by_region/data_by_region_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="covid19_italy_data_by_region",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.covid19_italy.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/covid19_italy/data_by_region/pipeline.yaml
+++ b/datasets/covid19_italy/data_by_region/pipeline.yaml
@@ -57,6 +57,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/covid19_italy/national_trends/national_trends_dag.py
+++ b/datasets/covid19_italy/national_trends/national_trends_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="covid19_italy_national_trends",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.covid19_italy.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/covid19_italy/national_trends/pipeline.yaml
+++ b/datasets/covid19_italy/national_trends/pipeline.yaml
@@ -58,6 +58,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/google_political_ads/advertiser_declared_stats/advertiser_declared_stats_dag.py
+++ b/datasets/google_political_ads/advertiser_declared_stats/advertiser_declared_stats_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="advertiser_declared_stats",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.google_political_ads.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/google_political_ads/advertiser_declared_stats/pipeline.yaml
+++ b/datasets/google_political_ads/advertiser_declared_stats/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment"s resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/google_political_ads/advertiser_geo_spend/advertiser_geo_spend_dag.py
+++ b/datasets/google_political_ads/advertiser_geo_spend/advertiser_geo_spend_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="advertiser_geo_spend",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.google_political_ads.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/google_political_ads/advertiser_geo_spend/pipeline.yaml
+++ b/datasets/google_political_ads/advertiser_geo_spend/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment"s resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/google_political_ads/advertiser_stats/advertiser_stats_dag.py
+++ b/datasets/google_political_ads/advertiser_stats/advertiser_stats_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="advertiser_stats",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.google_political_ads.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/google_political_ads/advertiser_stats/pipeline.yaml
+++ b/datasets/google_political_ads/advertiser_stats/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/google_political_ads/advertiser_weekly_spend/advertiser_weekly_spend_dag.py
+++ b/datasets/google_political_ads/advertiser_weekly_spend/advertiser_weekly_spend_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="advertiser_weekly_spend",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.google_political_ads.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/google_political_ads/advertiser_weekly_spend/pipeline.yaml
+++ b/datasets/google_political_ads/advertiser_weekly_spend/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/google_political_ads/campaign_targeting/campaign_targeting_dag.py
+++ b/datasets/google_political_ads/campaign_targeting/campaign_targeting_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="campaign_targeting",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.google_political_ads.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/google_political_ads/campaign_targeting/pipeline.yaml
+++ b/datasets/google_political_ads/campaign_targeting/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/google_political_ads/creative_stats/creative_stats_dag.py
+++ b/datasets/google_political_ads/creative_stats/creative_stats_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="creative_stats",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.google_political_ads.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/google_political_ads/creative_stats/pipeline.yaml
+++ b/datasets/google_political_ads/creative_stats/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/google_political_ads/geo_spend/geo_spend_dag.py
+++ b/datasets/google_political_ads/geo_spend/geo_spend_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="geo_spend",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.google_political_ads.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/google_political_ads/geo_spend/pipeline.yaml
+++ b/datasets/google_political_ads/geo_spend/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/google_political_ads/last_updated/last_updated_dag.py
+++ b/datasets/google_political_ads/last_updated/last_updated_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="last_updated",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.google_political_ads.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/google_political_ads/last_updated/pipeline.yaml
+++ b/datasets/google_political_ads/last_updated/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/google_political_ads/top_keywords_history/pipeline.yaml
+++ b/datasets/google_political_ads/top_keywords_history/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/google_political_ads/top_keywords_history/top_keywords_history_dag.py
+++ b/datasets/google_political_ads/top_keywords_history/top_keywords_history_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="top_keywords_history",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.google_political_ads.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/irs_990/irs_990_2014/irs_990_2014_dag.py
+++ b/datasets/irs_990/irs_990_2014/irs_990_2014_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="irs_990_2014",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.irs_990.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/irs_990/irs_990_2014/pipeline.yaml
+++ b/datasets/irs_990/irs_990_2014/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/irs_990/irs_990_2015/irs_990_2015_dag.py
+++ b/datasets/irs_990/irs_990_2015/irs_990_2015_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="irs_990_2015",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.irs_990.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/irs_990/irs_990_2015/pipeline.yaml
+++ b/datasets/irs_990/irs_990_2015/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/irs_990/irs_990_2016/irs_990_2016_dag.py
+++ b/datasets/irs_990/irs_990_2016/irs_990_2016_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="irs_990_2016",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.irs_990.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/irs_990/irs_990_2016/pipeline.yaml
+++ b/datasets/irs_990/irs_990_2016/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/irs_990/irs_990_2017/irs_990_2017_dag.py
+++ b/datasets/irs_990/irs_990_2017/irs_990_2017_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="irs_990_2017",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.irs_990.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/irs_990/irs_990_2017/pipeline.yaml
+++ b/datasets/irs_990/irs_990_2017/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/irs_990/irs_990_ez_2014/irs_990_ez_2014_dag.py
+++ b/datasets/irs_990/irs_990_ez_2014/irs_990_ez_2014_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="irs_990_ez_2014",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.irs_990.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/irs_990/irs_990_ez_2014/pipeline.yaml
+++ b/datasets/irs_990/irs_990_ez_2014/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/irs_990/irs_990_ez_2015/irs_990_ez_2015_dag.py
+++ b/datasets/irs_990/irs_990_ez_2015/irs_990_ez_2015_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="irs_990_ez_2015",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.irs_990.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/irs_990/irs_990_ez_2015/pipeline.yaml
+++ b/datasets/irs_990/irs_990_ez_2015/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/irs_990/irs_990_ez_2016/irs_990_ez_2016_dag.py
+++ b/datasets/irs_990/irs_990_ez_2016/irs_990_ez_2016_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="irs_990_ez_2016",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.irs_990.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/irs_990/irs_990_ez_2016/pipeline.yaml
+++ b/datasets/irs_990/irs_990_ez_2016/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/irs_990/irs_990_ez_2017/irs_990_ez_2017_dag.py
+++ b/datasets/irs_990/irs_990_ez_2017/irs_990_ez_2017_dag.py
@@ -38,6 +38,23 @@ with DAG(
         startup_timeout_seconds=600,
         name="irs_990_ez_2017",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.irs_990.container_registry.run_csv_transform_kub }}",
         env_vars={

--- a/datasets/irs_990/irs_990_ez_2017/pipeline.yaml
+++ b/datasets/irs_990/irs_990_ez_2017/pipeline.yaml
@@ -55,6 +55,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/irs_990/irs_990_pf_2014/irs_990_pf_2014_dag.py
+++ b/datasets/irs_990/irs_990_pf_2014/irs_990_pf_2014_dag.py
@@ -37,6 +37,23 @@ with DAG(
         task_id="irs_990_pf_2014_transform_csv",
         startup_timeout_seconds=600,
         name="irs_990_pf_2014",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         namespace="default",
         image_pull_policy="Always",
         image="{{ var.json.irs_990.container_registry.run_csv_transform_kub }}",

--- a/datasets/irs_990/irs_990_pf_2014/pipeline.yaml
+++ b/datasets/irs_990/irs_990_pf_2014/pipeline.yaml
@@ -52,6 +52,16 @@ dag:
         # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "irs_990_pf_2014"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 

--- a/datasets/irs_990/irs_990_pf_2015/irs_990_pf_2015_dag.py
+++ b/datasets/irs_990/irs_990_pf_2015/irs_990_pf_2015_dag.py
@@ -37,6 +37,23 @@ with DAG(
         task_id="irs_990_pf_2015_transform_csv",
         startup_timeout_seconds=600,
         name="irs_990_pf_2015",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         namespace="default",
         image_pull_policy="Always",
         image="{{ var.json.irs_990.container_registry.run_csv_transform_kub }}",

--- a/datasets/irs_990/irs_990_pf_2015/pipeline.yaml
+++ b/datasets/irs_990/irs_990_pf_2015/pipeline.yaml
@@ -52,6 +52,16 @@ dag:
         # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "irs_990_pf_2015"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 

--- a/datasets/irs_990/irs_990_pf_2016/irs_990_pf_2016_dag.py
+++ b/datasets/irs_990/irs_990_pf_2016/irs_990_pf_2016_dag.py
@@ -37,6 +37,23 @@ with DAG(
         task_id="irs_990_pf_2016_transform_csv",
         startup_timeout_seconds=600,
         name="irs_990_pf_2016",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         namespace="default",
         image_pull_policy="Always",
         image="{{ var.json.irs_990.container_registry.run_csv_transform_kub }}",

--- a/datasets/irs_990/irs_990_pf_2016/pipeline.yaml
+++ b/datasets/irs_990/irs_990_pf_2016/pipeline.yaml
@@ -52,6 +52,16 @@ dag:
         # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "irs_990_pf_2016"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 

--- a/datasets/noaa/gsod_stations/gsod_stations_dag.py
+++ b/datasets/noaa/gsod_stations/gsod_stations_dag.py
@@ -37,6 +37,23 @@ with DAG(
         task_id="transform_csv",
         name="gsod_stations",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.noaa_gsod_stations.container_registry.run_csv_transform_kub_gsod_stations }}",
         env_vars={

--- a/datasets/noaa/gsod_stations/pipeline.yaml
+++ b/datasets/noaa/gsod_stations/pipeline.yaml
@@ -54,6 +54,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/datasets/noaa/lightning_strikes_by_year/lightning_strikes_by_year_dag.py
+++ b/datasets/noaa/lightning_strikes_by_year/lightning_strikes_by_year_dag.py
@@ -37,6 +37,23 @@ with DAG(
         task_id="transform_csv",
         name="lightning_strikes_by_year",
         namespace="default",
+        affinity={
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "cloud.google.com/gke-nodepool",
+                                    "operator": "In",
+                                    "values": ["pool-e2-standard-4"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
         image_pull_policy="Always",
         image="{{ var.json.noaa_lightning_strikes_by_year.container_registry.run_csv_transform_kub_lightning_strikes_by_year }}",
         env_vars={

--- a/datasets/noaa/lightning_strikes_by_year/pipeline.yaml
+++ b/datasets/noaa/lightning_strikes_by_year/pipeline.yaml
@@ -54,6 +54,16 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:
+                        - "pool-e2-standard-4"
+
         image_pull_policy: "Always"
 
         # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.

--- a/samples/pipeline.yaml
+++ b/samples/pipeline.yaml
@@ -300,6 +300,17 @@ dag:
         # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "default"
 
+        # Use this attribute to constrain which node pools your pod must run in.
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: cloud.google.com/gke-nodepool
+                      operator: In
+                      values:  # Specify your node pools here
+                        - "pool-e2-standard-4"
+
         # The Google Container Registry image URL. To prepare a Docker image to be used by this operator:
         #
         # 1. Create an `_images` folder under your dataset folder if it doesn't exist.


### PR DESCRIPTION
## Description

All `KubernetesPodOperator`s are now using a separate node pool, as recommended by the [Google Cloud docs](https://cloud.google.com/composer/docs/how-to/using/using-kubernetes-pod-operator#environment-resources) and others.

## Checklist

Note: Delete items below that aren't applicable to your pull request.

- [x] Please merge this PR for me once it is approved.
- [x] If this PR adds or edits a dataset or pipeline, it was reviewed and approved by the Google Cloud Public Datasets team beforehand.
- [x] If this PR adds or edits a dataset or pipeline, I put all my code inside  `datasets/<YOUR-DATASET>` and nothing outside of that directory.
- [x] This PR is appropriately labeled.
