### PR TITLE
chore: Ignore *.tfvars files in datasets folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tmp
 .staging
 .prod
 
-# ignore nested Pipfiles and JSON files
+# ignore nested Pipfiles, JSON, and tfvars files
 /datasets/**/Pipfile
 /datasets/**/*.json
+/datasets/**/*.tfvars


### PR DESCRIPTION
## Description

Avoids unintentional checking in of `*.tfvars` files that contain specific values of GCP project IDs, service accounts, and Composer environments.

## Checklist

- [x] Please merge this PR for me once it is approved.
- [x] This PR is appropriately labeled.
