### PR TITLE
chore: Regenerate DAG files for `new_york` dataset

### DIFF
--- a/datasets/new_york/311_service_requests/311_service_requests_dag.py
+++ b/datasets/new_york/311_service_requests/311_service_requests_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="transform_csv",
         name="311_service_requests",
         namespace="default",
@@ -51,7 +52,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/new_york/311_service_requests/data_output.csv"],

--- a/datasets/new_york/citibike_stations/citibike_stations_dag.py
+++ b/datasets/new_york/citibike_stations/citibike_stations_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="transform_csv",
         name="citibike_stations",
         namespace="default",
@@ -52,7 +53,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/new_york/citibike_stations/data_output.csv"],

--- a/datasets/new_york/tree_census_1995/tree_census_1995_dag.py
+++ b/datasets/new_york/tree_census_1995/tree_census_1995_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="transform_csv",
         name="tree_census_1995",
         namespace="default",
@@ -51,7 +52,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/new_york/tree_census_1995/data_output.csv"],


### PR DESCRIPTION
## Description

The `new_york` pipelines are configured to use [Airflow 2](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/blob/5d5e2eac803538f0815f317f2653f0b9d74ee11c/datasets/new_york/citibike_stations/pipeline.yaml#L23) but the DAG files were never regenerated, i.e. the current ones in `main` are using Airflow 1. This PR regenerates them to use Airflow 2 operators.

## Checklist

- [x] Please merge this PR for me once it is approved.
- [x] If this PR adds or edits a dataset or pipeline, it was reviewed and approved by the Google Cloud Public Datasets team beforehand.
- [x] If this PR adds or edits a dataset or pipeline, I put all my code inside  `datasets/<YOUR-DATASET>` and nothing outside of that directory.
- [x] This PR is appropriately labeled.
