### PR TITLE
fix: Set `location` field as required for GCS buckets

### DIFF
--- a/samples/dataset.yaml
+++ b/samples/dataset.yaml
@@ -76,8 +76,9 @@ resources:
     #
     # Required Properties:
     #   name
+    #   location
     #
     # Optional Properties:
-    #   location
     #   uniform_bucket_level_access (we suggest False for fine-grained access)
     name: YOUR-BUCKET-NAME
+    location: US


### PR DESCRIPTION
## Description

The [latest release](https://github.com/hashicorp/terraform-provider-google/releases/tag/v4.0.0) from Terraform's Google provider changed the `location` field for GCS buckets to be required. This leads to failing unit tests for all PRs. This PR should unblock that.

## Checklist

- [x] Please merge this PR for me once it is approved.
- [x] This PR is appropriately labeled.
