### PR TITLE
fix: Allow other JSON files to be checked in (such as `schema.json`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ tmp
 
 # ignore nested Pipfiles, JSON, and tfvars files
 /datasets/**/Pipfile
-/datasets/**/*.json
+/datasets/**/*_variables.json
 /datasets/**/*.tfvars
 
 # ignore temp folders

--- a/datasets/idc/_images/copy_bq_datasets/script.py
+++ b/datasets/idc/_images/copy_bq_datasets/script.py
@@ -153,7 +153,7 @@ def trigger_config(
 ) -> None:
     now = time.time()
     seconds = int(now)
-    nanos = int((now - seconds) * 10 ** 9)
+    nanos = int((now - seconds) * 10**9)
 
     try:
         client.start_manual_transfer_runs(


### PR DESCRIPTION
## Description

We only ignore `*_variables.json` files because they contain environment specific info as well as potentially sensitive values.

This PR sets the stage to allow upcoming supporting for BQ schemas to specified in `schema.json` files, instead of having very long schema definitions in the YAML files.

## Checklist

- [x] Please merge this PR for me once it is approved.
- [x] This PR is appropriately labeled.
