### PR TITLE
feat: Upgrade some pipelines to Airflow 2 and explicitly set pod storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ tmp
 
 # ignore nested Pipfiles, JSON, and tfvars files
 /datasets/**/Pipfile
-/datasets/**/*.json
+/datasets/**/*_variables.json
 /datasets/**/*.tfvars
 
 # ignore temp folders

--- a/datasets/america_health_rankings/ahr/pipeline.yaml
+++ b/datasets/america_health_rankings/ahr/pipeline.yaml
@@ -21,7 +21,7 @@ resources:
 
 dag:
 
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: ahr
     default_args:
@@ -37,24 +37,15 @@ dag:
 
     - operator: "KubernetesPodOperator"
       description: "Run CSV transform within kubernetes pod"
+
       args:
         task_id: "ahr_transform_csv"
         startup_timeout_seconds: 600
         name: "america_health_rankings_ahr"
-        namespace: "default"
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: cloud.google.com/gke-nodepool
-                      operator: In
-                      values:
-                        - "pool-e2-standard-4"
-
+        namespace: "composer"
+        service_account_name: "datasets"
         image_pull_policy: "Always"
         image: "{{ var.json.america_health_rankings.container_registry.run_csv_transform_kub }}"
-
         env_vars:
           SOURCE_URL: "https://assets.americashealthrankings.org/app/uploads/ahr_heath-disparities_data.xlsx"
           SOURCE_FILE: "files/data.xlsx"
@@ -65,10 +56,10 @@ dag:
            ["edition","report_type","measure_name","state_name","subpopulation","value","lower_ci","upper_ci","source","source_date"]
           RENAME_MAPPINGS: >-
            {"Edition": "edition","Report Type": "report_type","Measure Name": "measure_name","State Name": "state_name","Subpopulation": "subpopulation","Value": "value","Lower CI": "lower_ci","Upper CI": "upper_ci","Source": "source","Source Date": "source_date"}
-
         resources:
-          limit_memory: "2G"
-          limit_cpu: "1"
+          request_memory: "2G"
+          request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/america_health_rankings/dataset.yaml
+++ b/datasets/america_health_rankings/dataset.yaml
@@ -21,11 +21,6 @@ dataset:
 
 
 resources:
-
   - type: bigquery_dataset
     dataset_id: america_health_rankings
     description: "America Health Rankings"
-  - type: storage_bucket
-    name: america-health-rankings
-    uniform_bucket_level_access: True
-    location: US

--- a/datasets/austin_bikeshare/bikeshare_stations/pipeline.yaml
+++ b/datasets/austin_bikeshare/bikeshare_stations/pipeline.yaml
@@ -23,7 +23,7 @@ resources:
     description: "Austin Bikeshare Stations table"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: bikeshare_stations
     default_args:
@@ -74,6 +74,7 @@ dag:
         resources:
           request_memory: "4G"
           request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/austin_crime/crime/crime_dag.py
+++ b/datasets/austin_crime/crime/crime_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    austin_crime_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    austin_crime_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="austin_crime_transform_csv",
         name="crime",
         namespace="composer",
@@ -50,11 +51,15 @@ with DAG(
             "CSV_HEADERS": '["unique_key","address","census_tract","clearance_date","clearance_status","council_district_code","description","district","latitude","longitude","location","location_description","primary_type","timestamp","x_coordinate","y_coordinate","year","zipcode"]',
             "RENAME_MAPPINGS": '{"GO Primary Key" : "unique_key","Council District" : "council_district_code","GO Highest Offense Desc" : "description","Highest NIBRS/UCR Offense Description" : "primary_type","GO Report Date" : "timestamp","GO Location" : "location_description","Clearance Status" : "clearance_status","Clearance Date" : "clearance_date","GO District" : "district","GO Location Zip" : "zipcode","GO Census Tract" : "census_tract","GO X Coordinate" : "x_coordinate","GO Y Coordinate" : "y_coordinate","Location_1" : "temp_address"}',
         },
-        resources={"request_memory": "4G", "request_cpu": "1"},
+        resources={
+            "request_memory": "4G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "10G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_austin_crime_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_austin_crime_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_austin_crime_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/austin_crime/crime/data_output.csv"],

--- a/datasets/austin_crime/crime/pipeline.yaml
+++ b/datasets/austin_crime/crime/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "Austin Crime table"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: crime
     default_args:
@@ -59,6 +59,7 @@ dag:
         resources:
           request_memory: "4G"
           request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/austin_waste/waste_and_diversion/pipeline.yaml
+++ b/datasets/austin_waste/waste_and_diversion/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "Austin waste and diversion"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: waste_and_diversion
     default_args:
@@ -53,8 +53,9 @@ dag:
           RENAME_MAPPINGS: >-
             {"Load ID": "load_id","Report Date": "report_date","Load Type": "load_type","Load Time": "load_time","Load Weight": "load_weight","Dropoff Site": "dropoff_site","Route Type": "route_type","Route Number": "route_number"}
         resources:
-          limit_memory: "2G"
-          limit_cpu: "1"
+          request_memory: "2G"
+          request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/austin_waste/waste_and_diversion/waste_and_diversion_dag.py
+++ b/datasets/austin_waste/waste_and_diversion/waste_and_diversion_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    austin_waste_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    austin_waste_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="austin_waste_transform_csv",
         startup_timeout_seconds=600,
         name="austin_waste",
@@ -50,30 +51,32 @@ with DAG(
             "CSV_HEADERS": '[ "load_id", "report_date", "load_type", "load_time", "load_weight", "dropoff_site", "route_type", "route_number"]',
             "RENAME_MAPPINGS": '{"Load ID": "load_id","Report Date": "report_date","Load Type": "load_type","Load Time": "load_time","Load Weight": "load_weight","Dropoff Site": "dropoff_site","Route Type": "route_type","Route Number": "route_number"}',
         },
-        resources={"limit_memory": "2G", "limit_cpu": "1"},
+        resources={
+            "request_memory": "2G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "10G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_austin_waste_and_diversion_to_bq = (
-        gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
-            task_id="load_austin_waste_and_diversion_to_bq",
-            bucket="{{ var.value.composer_bucket }}",
-            source_objects=["data/austin_waste/waste_and_diversion/data_output.csv"],
-            source_format="CSV",
-            destination_project_dataset_table="austin_waste.waste_and_diversion",
-            skip_leading_rows=1,
-            write_disposition="WRITE_TRUNCATE",
-            schema_fields=[
-                {"name": "load_id", "type": "INTEGER", "mode": "NULLABLE"},
-                {"name": "report_date", "type": "DATE", "mode": "NULLABLE"},
-                {"name": "load_type", "type": "STRING", "mode": "NULLABLE"},
-                {"name": "load_time", "type": "TIMESTAMP", "mode": "NULLABLE"},
-                {"name": "load_weight", "type": "FLOAT", "mode": "NULLABLE"},
-                {"name": "dropoff_site", "type": "STRING", "mode": "NULLABLE"},
-                {"name": "route_type", "type": "STRING", "mode": "NULLABLE"},
-                {"name": "route_number", "type": "STRING", "mode": "NULLABLE"},
-            ],
-        )
+    load_austin_waste_and_diversion_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
+        task_id="load_austin_waste_and_diversion_to_bq",
+        bucket="{{ var.value.composer_bucket }}",
+        source_objects=["data/austin_waste/waste_and_diversion/data_output.csv"],
+        source_format="CSV",
+        destination_project_dataset_table="austin_waste.waste_and_diversion",
+        skip_leading_rows=1,
+        write_disposition="WRITE_TRUNCATE",
+        schema_fields=[
+            {"name": "load_id", "type": "INTEGER", "mode": "NULLABLE"},
+            {"name": "report_date", "type": "DATE", "mode": "NULLABLE"},
+            {"name": "load_type", "type": "STRING", "mode": "NULLABLE"},
+            {"name": "load_time", "type": "TIMESTAMP", "mode": "NULLABLE"},
+            {"name": "load_weight", "type": "FLOAT", "mode": "NULLABLE"},
+            {"name": "dropoff_site", "type": "STRING", "mode": "NULLABLE"},
+            {"name": "route_type", "type": "STRING", "mode": "NULLABLE"},
+            {"name": "route_number", "type": "STRING", "mode": "NULLABLE"},
+        ],
     )
 
     austin_waste_transform_csv >> load_austin_waste_and_diversion_to_bq

--- a/datasets/bls/c_cpi_u/c_cpi_u_dag.py
+++ b/datasets/bls/c_cpi_u/c_cpi_u_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="transform_csv",
         startup_timeout_seconds=600,
         name="c_cpi_u",
@@ -53,11 +54,15 @@ with DAG(
             "TRIM_SPACE": '["series_id","value","footnote_codes","item_code"]',
             "CSV_HEADERS": '["series_id","year","period","value","footnote_codes","survey_abbreviation","seasonal_code","periodicity_code","area_code","area_name","item_code","item_name","date"]',
         },
-        resources={"request_memory": "2G", "request_cpu": "1"},
+        resources={
+            "request_memory": "2G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "10G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/bls/c_cpi_u/data_output.csv"],

--- a/datasets/bls/c_cpi_u/pipeline.yaml
+++ b/datasets/bls/c_cpi_u/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "C_CPI_U Dataset"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: "c_cpi_u"
     default_args:
@@ -64,6 +64,7 @@ dag:
         resources:
           request_memory: "2G"
           request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/bls/cpi_u/cpi_u_dag.py
+++ b/datasets/bls/cpi_u/cpi_u_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="transform_csv",
         startup_timeout_seconds=600,
         name="cpi_u",
@@ -52,11 +53,15 @@ with DAG(
             "TRIM_SPACE": '["series_id","value","footnote_codes"]',
             "CSV_HEADERS": '["series_id","year","period","value","footnote_codes","survey_abbreviation","seasonal_code","periodicity_code","area_code","area_name","item_code","item_name","date"]',
         },
-        resources={"request_memory": "2G", "request_cpu": "1"},
+        resources={
+            "request_memory": "2G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "10G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/bls/cpi_u/data_output.csv"],

--- a/datasets/bls/cpi_u/pipeline.yaml
+++ b/datasets/bls/cpi_u/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "CPI_U Dataset"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: "cpi_u"
     default_args:
@@ -61,6 +61,7 @@ dag:
         resources:
           request_memory: "2G"
           request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/bls/cpsaat18/cpsaat18_dag.py
+++ b/datasets/bls/cpsaat18/cpsaat18_dag.py
@@ -14,7 +14,7 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +33,7 @@ with DAG(
 ) as dag:
 
     # Task to load the CPSAAT18 data to the BigQuery table
-    load_csv_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_csv_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_csv_to_bq",
         bucket="{{ var.json.bls.source_bucket }}",
         source_objects=["cpsaat18/*.csv"],

--- a/datasets/bls/cpsaat18/pipeline.yaml
+++ b/datasets/bls/cpsaat18/pipeline.yaml
@@ -19,7 +19,7 @@ resources:
     description: "Current population survey 18: Employed persons by detailed industry, sex, race, and Hispanic or Latino ethnicity"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: cpsaat18
     default_args:

--- a/datasets/bls/dataset.yaml
+++ b/datasets/bls/dataset.yaml
@@ -31,5 +31,3 @@ resources:
       Terms of use: This dataset is publicly available for anyone to use under the following terms provided by the Dataset Source - http://www.data.gov/privacy-policy#data_policy - and is provided "AS IS" without any warranty, express or implied, from Google. Google disclaims all liability for any damages, direct or indirect, resulting from the use of the dataset.
 
       See the GCP Marketplace listing for more details and sample queries: https://console.cloud.google.com/marketplace/details/bls-public-data/bureau-of-labor-statistics
-  - type: storage_bucket
-    name: bls

--- a/datasets/bls/employment_hours_earnings/employment_hours_earnings_dag.py
+++ b/datasets/bls/employment_hours_earnings/employment_hours_earnings_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="transform_csv",
         startup_timeout_seconds=600,
         name="employment_hours_earnings",
@@ -53,11 +54,15 @@ with DAG(
             "TRIM_SPACE": '["series_id","value","footnote_codes","series_title"]',
             "CSV_HEADERS": '["series_id","year","period","value","footnote_codes","date","series_title"]',
         },
-        resources={"request_memory": "4G", "request_cpu": "1"},
+        resources={
+            "request_memory": "8G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "10G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/bls/employment_hours_earnings/data_output.csv"],

--- a/datasets/bls/employment_hours_earnings/pipeline.yaml
+++ b/datasets/bls/employment_hours_earnings/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "Employment_Hours_Earnings Dataset"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: "employment_hours_earnings"
     default_args:
@@ -60,8 +60,9 @@ dag:
           CSV_HEADERS: >-
             ["series_id","year","period","value","footnote_codes","date","series_title"]
         resources:
-          request_memory: "4G"
+          request_memory: "8G"
           request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/bls/employment_hours_earnings_series/employment_hours_earnings_series_dag.py
+++ b/datasets/bls/employment_hours_earnings_series/employment_hours_earnings_series_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="transform_csv",
         startup_timeout_seconds=600,
         name="employment_hours_earnings_series",
@@ -52,11 +53,15 @@ with DAG(
             "TRIM_SPACE": '["series_id","footnote_codes"]',
             "CSV_HEADERS": '["series_id","supersector_code","industry_code","data_type_code","seasonal","series_title","footnote_codes","begin_year","begin_period","end_year","end_period"]',
         },
-        resources={"request_memory": "4G", "request_cpu": "1"},
+        resources={
+            "request_memory": "4G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "10G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/bls/employment_hours_earnings_series/data_output.csv"],

--- a/datasets/bls/employment_hours_earnings_series/pipeline.yaml
+++ b/datasets/bls/employment_hours_earnings_series/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "Employment_Hours_Earnings_Series Dataset"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: "employment_hours_earnings_series"
     default_args:
@@ -61,6 +61,7 @@ dag:
         resources:
           request_memory: "4G"
           request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/bls/unemployment_cps/pipeline.yaml
+++ b/datasets/bls/unemployment_cps/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "Unemployment_CPS Dataset"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: "unemployment_cps"
     default_args:
@@ -59,8 +59,9 @@ dag:
           CSV_HEADERS: >-
             ["series_id","year","period","value","footnote_codes","date","series_title"]
         resources:
-          request_memory: "4G"
-          request_cpu: "1"
+          request_memory: "12G"
+          request_cpu: "2"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/bls/unemployment_cps/unemployment_cps_dag.py
+++ b/datasets/bls/unemployment_cps/unemployment_cps_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="transform_csv",
         startup_timeout_seconds=600,
         name="unemployment_cps",
@@ -52,11 +53,15 @@ with DAG(
             "TRIM_SPACE": '["series_id","value","footnote_codes","series_title"]',
             "CSV_HEADERS": '["series_id","year","period","value","footnote_codes","date","series_title"]',
         },
-        resources={"request_memory": "4G", "request_cpu": "1"},
+        resources={
+            "request_memory": "12G",
+            "request_cpu": "2",
+            "request_ephemeral_storage": "10G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/bls/unemployment_cps/data_output.csv"],

--- a/datasets/bls/unemployment_cps_series/pipeline.yaml
+++ b/datasets/bls/unemployment_cps_series/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "Unemployment_CPS_Series Dataset"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: "unemployment_cps_series"
     default_args:
@@ -60,6 +60,7 @@ dag:
         resources:
           request_memory: "4G"
           request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/bls/wm/pipeline.yaml
+++ b/datasets/bls/wm/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "WM  Dataset"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: "wm"
     default_args:

--- a/datasets/bls/wm/wm_dag.py
+++ b/datasets/bls/wm/wm_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="transform_csv",
         startup_timeout_seconds=600,
         name="wm",
@@ -56,7 +57,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/bls/wm/data_output.csv"],

--- a/datasets/bls/wm_series/pipeline.yaml
+++ b/datasets/bls/wm_series/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "WM_Series Dataset"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: "wm_series"
     default_args:

--- a/datasets/bls/wm_series/wm_series_dag.py
+++ b/datasets/bls/wm_series/wm_series_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="transform_csv",
         startup_timeout_seconds=600,
         name="wm_series",
@@ -56,7 +57,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/bls/wm_series/data_output.csv"],

--- a/datasets/cdc_chronic_disease_indicators/chronic_disease_indicators/pipeline.yaml
+++ b/datasets/cdc_chronic_disease_indicators/chronic_disease_indicators/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "CDC U.S. Chronic Disease Indicators (CDI)"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: chronic_disease_indicators
     default_args:
@@ -39,20 +39,10 @@ dag:
         task_id: "chronic_disease_transform_csv"
         startup_timeout_seconds: 600
         name: "cdc_chronic_disease_indicators_chronic_disease_indicators"
-        namespace: "default"
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: cloud.google.com/gke-nodepool
-                      operator: In
-                      values:
-                        - "pool-e2-standard-4"
-
+        namespace: "composer"
+        service_account_name: "datasets"
         image_pull_policy: "Always"
         image: "{{ var.json.cdc_chronic_disease_indicators.container_registry.run_csv_transform_kub }}"
-
         env_vars:
           SOURCE_URL: "https://chronicdata.cdc.gov/resource/g4ie-h725.csv"
           SOURCE_FILE: "files/data.csv"
@@ -65,8 +55,9 @@ dag:
            {"yearstart": "yearstart","yearend": "yearend","locationabbr": "locationabbr","locationdesc": "locationdesc","datasource": "datasource","topic": "topic","question": "question","response": "response","datavalueunit": "datavalueunit","datavaluetype": "datavaluetype","datavalue": "datavalue","datavaluealt": "datavaluealt","datavaluefootnotesymbol": "datavaluefootnotesymbol","datavaluefootnote": "datavaluefootnote","lowconfidencelimit": "lowconfidencelimit","highconfidencelimit": "highconfidencelimit","stratificationcategory1": "stratificationcategory1","stratification1": "stratification1","stratificationcategory2": "stratificationcategory2","stratification2": "stratification2","stratificationcategory3": "stratificationcategory3","stratification3": "stratification3","geolocation": "geolocation","responseid": "responseid","locationid": "locationid","topicid": "topicid","questionid": "questionid","datavaluetypeid": "datavaluetypeid","stratificationcategoryid1": "stratificationcategoryid1","stratificationid1": "stratificationid1","stratificationcategoryid2": "stratificationcategoryid2","stratificationid2": "stratificationid2","stratificationcategoryid3": "stratificationcategoryid3","stratificationid3": "stratificationid3"}
           PIPELINE_NAME: "chronic_disease_indicators"
         resources:
-          limit_memory: "2G"
-          limit_cpu: "1"
+          request_memory: "2G"
+          request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/cdc_chronic_disease_indicators/dataset.yaml
+++ b/datasets/cdc_chronic_disease_indicators/dataset.yaml
@@ -24,7 +24,3 @@ resources:
   - type: bigquery_dataset
     dataset_id: cdc_chronic_disease_indicators
     description: "CDC U.S. Chronic Disease Indicators (CDI)"
-  - type: storage_bucket
-    name: cdc-chronic-disease-indicators
-    uniform_bucket_level_access: True
-    location: US

--- a/datasets/cdc_places/local_data_for_better_health_county_data/pipeline.yaml
+++ b/datasets/cdc_places/local_data_for_better_health_county_data/pipeline.yaml
@@ -22,7 +22,7 @@ resources:
 
 dag:
 
-  airflow_version: 1
+  airflow_version: 2
 
   initialize:
     dag_id: local_data_for_better_health_county_data
@@ -69,8 +69,10 @@ dag:
           PIPELINE_NAME: "local_data_for_better_health_county_data"
 
         resources:
-          limit_memory: "4G"
-          limit_cpu: "2"
+          request_memory: "4G"
+          request_cpu: "2"
+          request_ephemeral_storage: "10G"
+
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/census_opportunity_atlas/dataset.yaml
+++ b/datasets/census_opportunity_atlas/dataset.yaml
@@ -24,7 +24,3 @@ resources:
   - type: bigquery_dataset
     dataset_id: census_opportunity_atlas
     description: "Census Opportunity Atlas"
-  - type: storage_bucket
-    name: census-opportunity-atlas
-    uniform_bucket_level_access: True
-    location: US

--- a/datasets/census_opportunity_atlas/tract_covariates/pipeline.yaml
+++ b/datasets/census_opportunity_atlas/tract_covariates/pipeline.yaml
@@ -22,7 +22,7 @@ resources:
 
 dag:
 
-  airflow_version: 1
+  airflow_version: 2
 
   initialize:
     dag_id: tract_covariates
@@ -48,19 +48,8 @@ dag:
         startup_timeout_seconds: 600
 
         name: "census_opportunity_atlas_tract_covariates"
-
-        namespace: "default"
-
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: cloud.google.com/gke-nodepool
-                      operator: In
-                      values:
-                        - "pool-e2-standard-4"
-
+        namespace: "composer"
+        service_account_name: "datasets"
         image_pull_policy: "Always"
 
         image: "{{ var.json.census_opportunity_atlas.container_registry.run_csv_transform_kub }}"
@@ -78,8 +67,9 @@ dag:
           PIPELINE_NAME: "tract_covariates"
 
         resources:
-          limit_memory: "2G"
-          limit_cpu: "1"
+          request_memory: "2G"
+          request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/cfpb_complaints/_terraform/cfpb_complaints_dataset.tf
+++ b/datasets/cfpb_complaints/_terraform/cfpb_complaints_dataset.tf
@@ -24,3 +24,19 @@ resource "google_bigquery_dataset" "cfpb_complaints" {
 output "bigquery_dataset-cfpb_complaints-dataset_id" {
   value = google_bigquery_dataset.cfpb_complaints.dataset_id
 }
+
+resource "google_storage_bucket" "cfpb-complaints" {
+  name                        = "${var.bucket_name_prefix}-cfpb-complaints"
+  force_destroy               = true
+  location                    = "US"
+  uniform_bucket_level_access = true
+  lifecycle {
+    ignore_changes = [
+      logging,
+    ]
+  }
+}
+
+output "storage_bucket-cfpb-complaints-name" {
+  value = google_storage_bucket.cfpb-complaints.name
+}

--- a/datasets/cfpb_complaints/complaint_database/pipeline.yaml
+++ b/datasets/cfpb_complaints/complaint_database/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "CFPB Complain table"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: complaint_database
     default_args:
@@ -38,16 +38,8 @@ dag:
         task_id: "complaint_database_transform_csv"
         startup_timeout_seconds: 600
         name: "complaint_database"
-        namespace: "default"
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: cloud.google.com/gke-nodepool
-                      operator: In
-                      values:
-                        - "pool-e2-standard-4"
+        namespace: "composer"
+        service_account_name: "datasets"
         image_pull_policy: "Always"
         image: "{{ var.json.cfpb_complaints.container_registry.run_csv_transform_kub }}"
         env_vars:
@@ -64,6 +56,7 @@ dag:
         resources:
           request_memory: "3G"
           request_cpu: "1"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/cfpb_complaints/dataset.yaml
+++ b/datasets/cfpb_complaints/dataset.yaml
@@ -24,7 +24,3 @@ resources:
   - type: bigquery_dataset
     dataset_id: cfpb_complaints
     description: CFPB Complaints dataset
-  - type: storage_bucket
-    name: cfpb-complaints
-    uniform_bucket_level_access: True
-    location: US

--- a/datasets/cms_medicare/hospital_general_info/hospital_general_info_dag.py
+++ b/datasets/cms_medicare/hospital_general_info/hospital_general_info_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    hospital_info_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    hospital_info_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="hospital_info_transform_csv",
         startup_timeout_seconds=600,
         name="cms_medicare_hospital_general_info",
@@ -51,11 +52,10 @@ with DAG(
             "RENAME_MAPPINGS": '{"Facility ID": "provider_id","Facility Name": "hospital_name","Address": "address","City": "city","State": "state","ZIP Code": "zip_code","County Name": "county_name","Phone Number": "phone_number","Hospital Type": "hospital_type","Hospital Ownership": "hospital_ownership","Emergency Services": "emergency_services","Meets criteria for promoting interoperability of EHRs": "meets_criteria_for_promoting_interoperability_of_ehrs","Hospital overall rating": "hospital_overall_rating","Hospital overall rating footnote": "hospital_overall_rating_footnote","MORT Group Measure Count": "mortality_group_measure_count","Count of Facility MORT Measures": "facility_mortaility_measures_count","Count of MORT Measures Better": "mortality_measures_better_count","Count of MORT Measures No Different": "mortality_measures_no_different_count","Count of MORT Measures Worse": "mortality_measures_worse_count","MORT Group Footnote": "mortaility_group_footnote","Safety Group Measure Count": "safety_measures_count","Count of Facility Safety Measures": "facility_care_safety_measures_count","Count of Safety Measures Better": "safety_measures_better_count","Count of Safety Measures No Different": "safety_measures_no_different_count","Count of Safety Measures Worse": "safety_measures_worse_count","Safety Group Footnote": "safety_group_footnote","READM Group Measure Count": "readmission_measures_count","Count of Facility READM Measures": "facility_readmission_measures_count","Count of READM Measures Better": "readmission_measures_better_count","Count of READM Measures No Different": "readmission_measures_no_different_count","Count of READM Measures Worse": "readmission_measures_worse_count","READM Group Footnote": "readmission_measures_footnote","Pt Exp Group Measure Count": "patient_experience_measures_count","Count of Facility Pt Exp Measures": "facility_patient_experience_measures_count","Pt Exp Group Footnote": "patient_experience_measures_footnote","TE Group Measure Count": "timely_and_effective_care_measures_count","Count of Facility TE Measures": "facility_timely_and_effective_care_measures_count","TE Group Footnote": "timely_and_effective_care_measures_footnote"}',
             "PIPELINE_NAME": "hospital_general_info",
         },
-        resources={"limit_memory": "2G", "limit_cpu": "1"},
     )
 
     # Task to load CSV data to a BigQuery table
-    load_hospital_info_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_hospital_info_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_hospital_info_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/cms_medicare/hospital_general_info/data_output.csv"],

--- a/datasets/cms_medicare/hospital_general_info/pipeline.yaml
+++ b/datasets/cms_medicare/hospital_general_info/pipeline.yaml
@@ -16,22 +16,15 @@
 resources:
 
   - type: bigquery_table
-    # Required Properties:
     table_id: hospital_general_info
-
-    # Description of the table
     description: "CMS Medicare Hospital General Info"
 
 dag:
-
-  airflow_version: 1
-
+  airflow_version: 2
   initialize:
     dag_id: hospital_general_info
     default_args:
       owner: "Google"
-
-      # When set to True, keeps a task from getting triggered if the previous schedule for the task hasn’t succeeded
       depends_on_past: False
       start_date: '2021-03-01'
     max_active_runs: 1
@@ -42,28 +35,15 @@ dag:
   tasks:
 
     - operator: "KubernetesPodOperator"
-
-      # Task description
       description: "Run CSV transform within kubernetes pod"
-
       args:
-
         task_id: "hospital_info_transform_csv"
         startup_timeout_seconds: 600
-
-        # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "cms_medicare_hospital_general_info"
-
-        # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "composer"
         service_account_name: "datasets"
-
         image_pull_policy: "Always"
-
-        # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.
         image: "{{ var.json.cms_medicare.container_registry.run_csv_transform_kub }}"
-
-        # Set the environment variables you need initialized in the container. Use these as input variables for the script your container is expected to perform.
         env_vars:
           SOURCE_URL: "https://data.cms.gov/provider-data/sites/default/files/resources/092256becd267d9eeccf73bf7d16c46b_1623902717/Hospital_General_Information.csv"
           SOURCE_FILE: "files/data.csv"
@@ -76,37 +56,16 @@ dag:
            {"Facility ID": "provider_id","Facility Name": "hospital_name","Address": "address","City": "city","State": "state","ZIP Code": "zip_code","County Name": "county_name","Phone Number": "phone_number","Hospital Type": "hospital_type","Hospital Ownership": "hospital_ownership","Emergency Services": "emergency_services","Meets criteria for promoting interoperability of EHRs": "meets_criteria_for_promoting_interoperability_of_ehrs","Hospital overall rating": "hospital_overall_rating","Hospital overall rating footnote": "hospital_overall_rating_footnote","MORT Group Measure Count": "mortality_group_measure_count","Count of Facility MORT Measures": "facility_mortaility_measures_count","Count of MORT Measures Better": "mortality_measures_better_count","Count of MORT Measures No Different": "mortality_measures_no_different_count","Count of MORT Measures Worse": "mortality_measures_worse_count","MORT Group Footnote": "mortaility_group_footnote","Safety Group Measure Count": "safety_measures_count","Count of Facility Safety Measures": "facility_care_safety_measures_count","Count of Safety Measures Better": "safety_measures_better_count","Count of Safety Measures No Different": "safety_measures_no_different_count","Count of Safety Measures Worse": "safety_measures_worse_count","Safety Group Footnote": "safety_group_footnote","READM Group Measure Count": "readmission_measures_count","Count of Facility READM Measures": "facility_readmission_measures_count","Count of READM Measures Better": "readmission_measures_better_count","Count of READM Measures No Different": "readmission_measures_no_different_count","Count of READM Measures Worse": "readmission_measures_worse_count","READM Group Footnote": "readmission_measures_footnote","Pt Exp Group Measure Count": "patient_experience_measures_count","Count of Facility Pt Exp Measures": "facility_patient_experience_measures_count","Pt Exp Group Footnote": "patient_experience_measures_footnote","TE Group Measure Count": "timely_and_effective_care_measures_count","Count of Facility TE Measures": "facility_timely_and_effective_care_measures_count","TE Group Footnote": "timely_and_effective_care_measures_footnote"}
           PIPELINE_NAME: "hospital_general_info"
 
-        # Set resource limits for the pod here. For resource units in Kubernetes, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
-        resources:
-          limit_memory: "2G"
-          limit_cpu: "1"
-
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
-
       args:
         task_id: "load_hospital_info_to_bq"
-
-        # The GCS bucket where the CSV file is located in.
         bucket: "{{ var.value.composer_bucket }}"
-
-        # The GCS object path for the CSV file
         source_objects: ["data/cms_medicare/hospital_general_info/data_output.csv"]
         source_format: "CSV"
         destination_project_dataset_table: "cms_medicare.hospital_general_info"
-
-        # Use this if your CSV file contains a header row
         skip_leading_rows: 1
-
-        # How to write data to the table: overwrite, append, or write if empty
-        # See https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
         write_disposition: "WRITE_TRUNCATE"
-
-        # The BigQuery table schema based on the CSV file. For more info, see
-        # https://cloud.google.com/bigquery/docs/schemas.
-        # Always use snake_case and lowercase for column names, and be explicit,
-        # i.e. specify modes for all columns.
-        # types: "INTEGER", "TIMESTAMP", "STRING"
         schema_fields:
           - name: "provider_id"
             type: "STRING"

--- a/datasets/cms_medicare/inpatient_charges/inpatient_charges_dag.py
+++ b/datasets/cms_medicare/inpatient_charges/inpatient_charges_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    inpatient_2011_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    inpatient_2011_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="inpatient_2011_transform_csv",
         startup_timeout_seconds=600,
         name="cms_medicare_inpatient_charges_2011",
@@ -55,7 +56,7 @@ with DAG(
     )
 
     # Run CSV transform within kubernetes pod
-    inpatient_2012_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    inpatient_2012_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="inpatient_2012_transform_csv",
         startup_timeout_seconds=600,
         name="cms_medicare_inpatient_charges_2012",
@@ -77,7 +78,7 @@ with DAG(
     )
 
     # Run CSV transform within kubernetes pod
-    inpatient_2013_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    inpatient_2013_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="inpatient_2013_transform_csv",
         startup_timeout_seconds=600,
         name="cms_medicare_inpatient_charges_2013",
@@ -99,7 +100,7 @@ with DAG(
     )
 
     # Run CSV transform within kubernetes pod
-    inpatient_2014_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    inpatient_2014_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="inpatient_2014_transform_csv",
         startup_timeout_seconds=600,
         name="cms_medicare_inpatient_charges_2014",
@@ -121,7 +122,7 @@ with DAG(
     )
 
     # Run CSV transform within kubernetes pod
-    inpatient_2015_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    inpatient_2015_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="inpatient_2015_transform_csv",
         startup_timeout_seconds=600,
         name="cms_medicare_inpatient_charges_2015",
@@ -143,7 +144,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_inpatient_2011_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_inpatient_2011_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_inpatient_2011_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/cms_medicare/inpatient_charges_2011/data_output.csv"],
@@ -228,7 +229,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_inpatient_2012_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_inpatient_2012_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_inpatient_2012_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/cms_medicare/inpatient_charges_2012/data_output.csv"],
@@ -313,7 +314,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_inpatient_2013_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_inpatient_2013_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_inpatient_2013_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/cms_medicare/inpatient_charges_2013/data_output.csv"],
@@ -398,7 +399,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_inpatient_2014_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_inpatient_2014_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_inpatient_2014_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/cms_medicare/inpatient_charges_2014/data_output.csv"],
@@ -483,7 +484,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_inpatient_2015_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_inpatient_2015_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_inpatient_2015_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/cms_medicare/inpatient_charges_2015/data_output.csv"],

--- a/datasets/cms_medicare/inpatient_charges/pipeline.yaml
+++ b/datasets/cms_medicare/inpatient_charges/pipeline.yaml
@@ -16,50 +16,31 @@
 resources:
 
   - type: bigquery_table
-    # Required Properties:
     table_id: inpatient_charges_2011
-
-    # Description of the table
     description: "CMS Medicare Inpatient Charges 2011"
 
   - type: bigquery_table
-    # Required Properties:
     table_id: inpatient_charges_2012
-
-    # Description of the table
     description: "CMS Medicare Inpatient Charges 2012"
 
   - type: bigquery_table
-    # Required Properties:
     table_id: inpatient_charges_2013
-
-    # Description of the table
     description: "CMS Medicare Inpatient Charges 2013"
 
   - type: bigquery_table
-    # Required Properties:
     table_id: inpatient_charges_2014
-
-    # Description of the table
     description: "CMS Medicare Inpatient Charges 2014"
 
   - type: bigquery_table
-    # Required Properties:
     table_id: inpatient_charges_2015
-
-    # Description of the table
     description: "CMS Medicare Inpatient Charges 2015"
 
 dag:
-
-  airflow_version: 1
-
+  airflow_version: 2
   initialize:
     dag_id: inpatient_charges
     default_args:
       owner: "Google"
-
-      # When set to True, keeps a task from getting triggered if the previous schedule for the task hasn’t succeeded
       depends_on_past: False
       start_date: '2021-03-01'
     max_active_runs: 1
@@ -68,30 +49,16 @@ dag:
     default_view: graph
 
   tasks:
-
     - operator: "KubernetesPodOperator"
-
-      # Task description
       description: "Run CSV transform within kubernetes pod"
-
       args:
-
         task_id: "inpatient_2011_transform_csv"
         startup_timeout_seconds: 600
-
-        # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "cms_medicare_inpatient_charges_2011"
-
-        # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "composer"
         service_account_name: "datasets"
-
         image_pull_policy: "Always"
-
-        # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.
         image: "{{ var.json.cms_medicare.container_registry.run_csv_transform_kub }}"
-
-        # Set the environment variables you need initialized in the container. Use these as input variables for the script your container is expected to perform.
         env_vars:
           SOURCE_URL: "https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/Medicare-Provider-Charge-Data/Downloads/Inpatient_Data_2011_CSV.zip"
           SOURCE_FILE: "files/data.zip"
@@ -103,35 +70,20 @@ dag:
           RENAME_MAPPINGS: >-
            {"Provider Id": "provider_id","Provider Name": "provider_name","Provider Street Address": "provider_street_address","Provider City": "provider_city","Provider State": "provider_state","Provider Zip Code": "provider_zipcode","DRG Definition": "drg_definition","Hospital Referral Region (HRR) Description": "hospital_referral_region_description","Total Discharges": "total_discharges","Average Covered Charges": "average_covered_charges","Average Total Payments": "average_total_payments","Average Medicare Payments": "average_medicare_payments"}
           PIPELINE_NAME: "inpatient_charges_2011"
-
-        # Set resource limits for the pod here. For resource units in Kubernetes, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
         resources:
           limit_memory: "2G"
           limit_cpu: "1"
 
     - operator: "KubernetesPodOperator"
-
-      # Task description
       description: "Run CSV transform within kubernetes pod"
-
       args:
-
         task_id: "inpatient_2012_transform_csv"
         startup_timeout_seconds: 600
-
-        # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "cms_medicare_inpatient_charges_2012"
-
-        # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "composer"
         service_account_name: "datasets"
-
         image_pull_policy: "Always"
-
-        # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.
         image: "{{ var.json.cms_medicare.container_registry.run_csv_transform_kub }}"
-
-        # Set the environment variables you need initialized in the container. Use these as input variables for the script your container is expected to perform.
         env_vars:
           SOURCE_URL: "https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/Medicare-Provider-Charge-Data/Downloads/Inpatient_Data_2012_CSV.zip"
           SOURCE_FILE: "files/data.zip"
@@ -143,35 +95,20 @@ dag:
           RENAME_MAPPINGS: >-
            {"Provider Id": "provider_id","Provider Name": "provider_name","Provider Street Address": "provider_street_address","Provider City": "provider_city","Provider State": "provider_state","Provider Zip Code": "provider_zipcode","DRG Definition": "drg_definition","Hospital Referral Region (HRR) Description": "hospital_referral_region_description","Total Discharges": "total_discharges","Average Covered Charges": "average_covered_charges","Average Total Payments": "average_total_payments","Average Medicare Payments": "average_medicare_payments"}
           PIPELINE_NAME: "inpatient_charges_2012"
-
-        # Set resource limits for the pod here. For resource units in Kubernetes, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
         resources:
           limit_memory: "2G"
           limit_cpu: "1"
 
     - operator: "KubernetesPodOperator"
-
-      # Task description
       description: "Run CSV transform within kubernetes pod"
-
       args:
-
         task_id: "inpatient_2013_transform_csv"
         startup_timeout_seconds: 600
-
-        # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "cms_medicare_inpatient_charges_2013"
-
-        # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "composer"
         service_account_name: "datasets"
-
         image_pull_policy: "Always"
-
-        # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.
         image: "{{ var.json.cms_medicare.container_registry.run_csv_transform_kub }}"
-
-        # Set the environment variables you need initialized in the container. Use these as input variables for the script your container is expected to perform.
         env_vars:
           SOURCE_URL: "https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/Medicare-Provider-Charge-Data/Downloads/Inpatient_Data_2013_CSV.zip"
           SOURCE_FILE: "files/data.zip"
@@ -183,35 +120,20 @@ dag:
           RENAME_MAPPINGS: >-
            {"Provider Id": "provider_id","Provider Name": "provider_name","Provider Street Address": "provider_street_address","Provider City": "provider_city","Provider State": "provider_state","Provider Zip Code": "provider_zipcode","DRG Definition": "drg_definition","Hospital Referral Region (HRR) Description": "hospital_referral_region_description","Total Discharges": "total_discharges","Average Covered Charges": "average_covered_charges","Average Total Payments": "average_total_payments","Average Medicare Payments": "average_medicare_payments"}
           PIPELINE_NAME: "inpatient_charges_2013"
-
-        # Set resource limits for the pod here. For resource units in Kubernetes, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
         resources:
           limit_memory: "2G"
           limit_cpu: "1"
 
     - operator: "KubernetesPodOperator"
-
-      # Task description
       description: "Run CSV transform within kubernetes pod"
-
       args:
-
         task_id: "inpatient_2014_transform_csv"
         startup_timeout_seconds: 600
-
-        # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "cms_medicare_inpatient_charges_2014"
-
-        # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "composer"
         service_account_name: "datasets"
-
         image_pull_policy: "Always"
-
-        # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.
         image: "{{ var.json.cms_medicare.container_registry.run_csv_transform_kub }}"
-
-        # Set the environment variables you need initialized in the container. Use these as input variables for the script your container is expected to perform.
         env_vars:
           SOURCE_URL: "https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/Medicare-Provider-Charge-Data/Downloads/Inpatient_Data_2014_CSV.zip"
           SOURCE_FILE: "files/data.zip"
@@ -223,35 +145,20 @@ dag:
           RENAME_MAPPINGS: >-
            {"Provider Id": "provider_id","Provider Name": "provider_name","Provider Street Address": "provider_street_address","Provider City": "provider_city","Provider State": "provider_state","Provider Zip Code": "provider_zipcode","DRG Definition": "drg_definition","Hospital Referral Region (HRR) Description": "hospital_referral_region_description","Total Discharges": "total_discharges","Average Covered Charges": "average_covered_charges","Average Total Payments": "average_total_payments","Average Medicare Payments": "average_medicare_payments"}
           PIPELINE_NAME: "inpatient_charges_2014"
-
-        # Set resource limits for the pod here. For resource units in Kubernetes, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
         resources:
           limit_memory: "2G"
           limit_cpu: "1"
 
     - operator: "KubernetesPodOperator"
-
-      # Task description
       description: "Run CSV transform within kubernetes pod"
-
       args:
-
         task_id: "inpatient_2015_transform_csv"
         startup_timeout_seconds: 600
-
-        # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "cms_medicare_inpatient_charges_2015"
-
-        # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "composer"
         service_account_name: "datasets"
-
         image_pull_policy: "Always"
-
-        # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.
         image: "{{ var.json.cms_medicare.container_registry.run_csv_transform_kub }}"
-
-        # Set the environment variables you need initialized in the container. Use these as input variables for the script your container is expected to perform.
         env_vars:
           SOURCE_URL: "https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/Medicare-Provider-Charge-Data/Downloads/Inpatient_Data_2015_CSV.zip"
           SOURCE_FILE: "files/data.zip"
@@ -263,38 +170,20 @@ dag:
           RENAME_MAPPINGS: >-
            {"Provider Id": "provider_id","Provider Name": "provider_name","Provider Street Address": "provider_street_address","Provider City": "provider_city","Provider State": "provider_state","Provider Zip Code": "provider_zipcode","DRG Definition": "drg_definition","Hospital Referral Region (HRR) Description": "hospital_referral_region_description","Total Discharges": "total_discharges","Average Covered Charges": "average_covered_charges","Average Total Payments": "average_total_payments","Average Medicare Payments": "average_medicare_payments"}
           PIPELINE_NAME: "inpatient_charges_2015"
-
-        # Set resource limits for the pod here. For resource units in Kubernetes, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
         resources:
           limit_memory: "2G"
           limit_cpu: "1"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
-
       args:
         task_id: "load_inpatient_2011_to_bq"
-
-        # The GCS bucket where the CSV file is located in.
         bucket: "{{ var.value.composer_bucket }}"
-
-        # The GCS object path for the CSV file
         source_objects: ["data/cms_medicare/inpatient_charges_2011/data_output.csv"]
         source_format: "CSV"
         destination_project_dataset_table: "cms_medicare.inpatient_charges_2011"
-
-        # Use this if your CSV file contains a header row
         skip_leading_rows: 1
-
-        # How to write data to the table: overwrite, append, or write if empty
-        # See https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
         write_disposition: "WRITE_TRUNCATE"
-
-        # The BigQuery table schema based on the CSV file. For more info, see
-        # https://cloud.google.com/bigquery/docs/schemas.
-        # Always use snake_case and lowercase for column names, and be explicit,
-        # i.e. specify modes for all columns.
-        # types: "INTEGER", "TIMESTAMP", "STRING"
         schema_fields:
           - description: "The CMS Certification Number (CCN) of the provider billing for outpatient hospital services"
             name: "provider_id"
@@ -347,30 +236,14 @@ dag:
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
-
       args:
         task_id: "load_inpatient_2012_to_bq"
-
-        # The GCS bucket where the CSV file is located in.
         bucket: "{{ var.value.composer_bucket }}"
-
-        # The GCS object path for the CSV file
         source_objects: ["data/cms_medicare/inpatient_charges_2012/data_output.csv"]
         source_format: "CSV"
         destination_project_dataset_table: "cms_medicare.inpatient_charges_2012"
-
-        # Use this if your CSV file contains a header row
         skip_leading_rows: 1
-
-        # How to write data to the table: overwrite, append, or write if empty
-        # See https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
         write_disposition: "WRITE_TRUNCATE"
-
-        # The BigQuery table schema based on the CSV file. For more info, see
-        # https://cloud.google.com/bigquery/docs/schemas.
-        # Always use snake_case and lowercase for column names, and be explicit,
-        # i.e. specify modes for all columns.
-        # types: "INTEGER", "TIMESTAMP", "STRING"
         schema_fields:
           - description: "The CMS Certification Number (CCN) of the provider billing for outpatient hospital services"
             name: "provider_id"
@@ -423,30 +296,14 @@ dag:
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
-
       args:
         task_id: "load_inpatient_2013_to_bq"
-
-        # The GCS bucket where the CSV file is located in.
         bucket: "{{ var.value.composer_bucket }}"
-
-        # The GCS object path for the CSV file
         source_objects: ["data/cms_medicare/inpatient_charges_2013/data_output.csv"]
         source_format: "CSV"
         destination_project_dataset_table: "cms_medicare.inpatient_charges_2013"
-
-        # Use this if your CSV file contains a header row
         skip_leading_rows: 1
-
-        # How to write data to the table: overwrite, append, or write if empty
-        # See https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
         write_disposition: "WRITE_TRUNCATE"
-
-        # The BigQuery table schema based on the CSV file. For more info, see
-        # https://cloud.google.com/bigquery/docs/schemas.
-        # Always use snake_case and lowercase for column names, and be explicit,
-        # i.e. specify modes for all columns.
-        # types: "INTEGER", "TIMESTAMP", "STRING"
         schema_fields:
           - description: "The CMS Certification Number (CCN) of the provider billing for outpatient hospital services"
             name: "provider_id"
@@ -499,30 +356,14 @@ dag:
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
-
       args:
         task_id: "load_inpatient_2014_to_bq"
-
-        # The GCS bucket where the CSV file is located in.
         bucket: "{{ var.value.composer_bucket }}"
-
-        # The GCS object path for the CSV file
         source_objects: ["data/cms_medicare/inpatient_charges_2014/data_output.csv"]
         source_format: "CSV"
         destination_project_dataset_table: "cms_medicare.inpatient_charges_2014"
-
-        # Use this if your CSV file contains a header row
         skip_leading_rows: 1
-
-        # How to write data to the table: overwrite, append, or write if empty
-        # See https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
         write_disposition: "WRITE_TRUNCATE"
-
-        # The BigQuery table schema based on the CSV file. For more info, see
-        # https://cloud.google.com/bigquery/docs/schemas.
-        # Always use snake_case and lowercase for column names, and be explicit,
-        # i.e. specify modes for all columns.
-        # types: "INTEGER", "TIMESTAMP", "STRING"
         schema_fields:
           - description: "The CMS Certification Number (CCN) of the provider billing for outpatient hospital services"
             name: "provider_id"
@@ -575,30 +416,14 @@ dag:
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
-
       args:
         task_id: "load_inpatient_2015_to_bq"
-
-        # The GCS bucket where the CSV file is located in.
         bucket: "{{ var.value.composer_bucket }}"
-
-        # The GCS object path for the CSV file
         source_objects: ["data/cms_medicare/inpatient_charges_2015/data_output.csv"]
         source_format: "CSV"
         destination_project_dataset_table: "cms_medicare.inpatient_charges_2015"
-
-        # Use this if your CSV file contains a header row
         skip_leading_rows: 1
-
-        # How to write data to the table: overwrite, append, or write if empty
-        # See https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
         write_disposition: "WRITE_TRUNCATE"
-
-        # The BigQuery table schema based on the CSV file. For more info, see
-        # https://cloud.google.com/bigquery/docs/schemas.
-        # Always use snake_case and lowercase for column names, and be explicit,
-        # i.e. specify modes for all columns.
-        # types: "INTEGER", "TIMESTAMP", "STRING"
         schema_fields:
           - description: "The CMS Certification Number (CCN) of the provider billing for outpatient hospital services"
             name: "provider_id"

--- a/datasets/cms_medicare/outpatient_charges/outpatient_charges_dag.py
+++ b/datasets/cms_medicare/outpatient_charges/outpatient_charges_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    outpatient_2011_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    outpatient_2011_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="outpatient_2011_transform_csv",
         startup_timeout_seconds=600,
         name="cms_medicare_outpatient_charges_2011",
@@ -54,7 +55,7 @@ with DAG(
     )
 
     # Run CSV transform within kubernetes pod
-    outpatient_2012_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    outpatient_2012_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="outpatient_2012_transform_csv",
         startup_timeout_seconds=600,
         name="cms_medicare_outpatient_charges_2012",
@@ -75,7 +76,7 @@ with DAG(
     )
 
     # Run CSV transform within kubernetes pod
-    outpatient_2013_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    outpatient_2013_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="outpatient_2013_transform_csv",
         startup_timeout_seconds=600,
         name="cms_medicare_outpatient_charges_2013",
@@ -96,7 +97,7 @@ with DAG(
     )
 
     # Run CSV transform within kubernetes pod
-    outpatient_2014_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    outpatient_2014_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="outpatient_2014_transform_csv",
         startup_timeout_seconds=600,
         name="cms_medicare_outpatient_charges_2014",
@@ -118,7 +119,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_outpatient_2011_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_outpatient_2011_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_outpatient_2011_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/cms_medicare/outpatient_charges_2011/data_output.csv"],
@@ -197,7 +198,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_outpatient_2012_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_outpatient_2012_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_outpatient_2012_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/cms_medicare/outpatient_charges_2012/data_output.csv"],
@@ -276,7 +277,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_outpatient_2013_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_outpatient_2013_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_outpatient_2013_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/cms_medicare/outpatient_charges_2013/data_output.csv"],
@@ -355,7 +356,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_outpatient_2014_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_outpatient_2014_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_outpatient_2014_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/cms_medicare/outpatient_charges_2014/data_output.csv"],

--- a/datasets/cms_medicare/outpatient_charges/pipeline.yaml
+++ b/datasets/cms_medicare/outpatient_charges/pipeline.yaml
@@ -16,43 +16,28 @@
 resources:
 
   - type: bigquery_table
-    # Required Properties:
     table_id: outpatient_charges_2011
-
-    # Description of the table
     description: "CMS Medicare Outpatient Charges 2011"
 
   - type: bigquery_table
-    # Required Properties:
     table_id: outpatient_charges_2012
-
-    # Description of the table
     description: "CMS Medicare Outpatient Charges 2012"
 
   - type: bigquery_table
-    # Required Properties:
     table_id: outpatient_charges_2013
-
-    # Description of the table
     description: "CMS Medicare Outpatient Charges 2013"
 
   - type: bigquery_table
-    # Required Properties:
     table_id: outpatient_charges_2014
-
-    # Description of the table
     description: "CMS Medicare Outpatient Charges 2014"
 
 dag:
 
-  airflow_version: 1
-
+  airflow_version: 2
   initialize:
     dag_id: outpatient_charges
     default_args:
       owner: "Google"
-
-      # When set to True, keeps a task from getting triggered if the previous schedule for the task hasn’t succeeded
       depends_on_past: False
       start_date: '2021-03-01'
     max_active_runs: 1
@@ -61,30 +46,16 @@ dag:
     default_view: graph
 
   tasks:
-
     - operator: "KubernetesPodOperator"
-
-      # Task description
       description: "Run CSV transform within kubernetes pod"
-
       args:
-
         task_id: "outpatient_2011_transform_csv"
         startup_timeout_seconds: 600
-
-        # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "cms_medicare_outpatient_charges_2011"
-
-        # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "composer"
         service_account_name: "datasets"
-
         image_pull_policy: "Always"
-
-        # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.
         image: "{{ var.json.cms_medicare.container_registry.run_csv_transform_kub }}"
-
-        # Set the environment variables you need initialized in the container. Use these as input variables for the script your container is expected to perform.
         env_vars:
           SOURCE_URL: "https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/Medicare-Provider-Charge-Data/Downloads/Outpatient_Data_2011_CSV.zip"
           SOURCE_FILE: "files/data.zip"
@@ -98,28 +69,15 @@ dag:
           PIPELINE_NAME: "outpatient_charges_2011"
 
     - operator: "KubernetesPodOperator"
-
-      # Task description
       description: "Run CSV transform within kubernetes pod"
-
       args:
-
         task_id: "outpatient_2012_transform_csv"
         startup_timeout_seconds: 600
-
-        # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "cms_medicare_outpatient_charges_2012"
-
-        # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "composer"
         service_account_name: "datasets"
-
         image_pull_policy: "Always"
-
-        # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.
         image: "{{ var.json.cms_medicare.container_registry.run_csv_transform_kub }}"
-
-        # Set the environment variables you need initialized in the container. Use these as input variables for the script your container is expected to perform.
         env_vars:
           SOURCE_URL: "https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/Medicare-Provider-Charge-Data/Downloads/Outpatient_Data_2012_CSV.zip"
           SOURCE_FILE: "files/data.zip"
@@ -133,28 +91,15 @@ dag:
           PIPELINE_NAME: "outpatient_charges_2012"
 
     - operator: "KubernetesPodOperator"
-
-      # Task description
       description: "Run CSV transform within kubernetes pod"
-
       args:
-
         task_id: "outpatient_2013_transform_csv"
         startup_timeout_seconds: 600
-
-        # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "cms_medicare_outpatient_charges_2013"
-
-        # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "composer"
         service_account_name: "datasets"
-
         image_pull_policy: "Always"
-
-        # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.
         image: "{{ var.json.cms_medicare.container_registry.run_csv_transform_kub }}"
-
-        # Set the environment variables you need initialized in the container. Use these as input variables for the script your container is expected to perform.
         env_vars:
           SOURCE_URL: "https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/Medicare-Provider-Charge-Data/Downloads/Outpatient_Data_2013_CSV_v2.zip"
           SOURCE_FILE: "files/data.zip"
@@ -168,28 +113,15 @@ dag:
           PIPELINE_NAME: "outpatient_charges_2013"
 
     - operator: "KubernetesPodOperator"
-
-      # Task description
       description: "Run CSV transform within kubernetes pod"
-
       args:
-
         task_id: "outpatient_2014_transform_csv"
         startup_timeout_seconds: 600
-
-        # The name of the pod in which the task will run. This will be used (plus a random suffix) to generate a pod id
         name: "cms_medicare_outpatient_charges_2014"
-
-        # The namespace to run within Kubernetes. Always set its value to "default" because we follow the guideline that KubernetesPodOperator will only be used for very light workloads, i.e. use the Cloud Composer environment's resources without starving other pipelines.
         namespace: "composer"
         service_account_name: "datasets"
-
         image_pull_policy: "Always"
-
-        # Docker images will be built and pushed to GCR by default whenever the `scripts/generate_dag.py` is run. To skip building and pushing images, use the optional `--skip-builds` flag.
         image: "{{ var.json.cms_medicare.container_registry.run_csv_transform_kub }}"
-
-        # Set the environment variables you need initialized in the container. Use these as input variables for the script your container is expected to perform.
         env_vars:
           SOURCE_URL: "https://www.cms.gov/Research-Statistics-Data-and-Systems/Statistics-Trends-and-Reports/Medicare-Provider-Charge-Data/Downloads/Outpatient_Data_2014_CSV.zip"
           SOURCE_FILE: "files/data.zip"
@@ -201,38 +133,20 @@ dag:
           RENAME_MAPPINGS: >-
            {"provider_id": "provider_id","provider_name": "provider_name","Provider_Street_Address": "provider_street_address","Provider_City": "provider_city","Provider_State": "provider_state","Provider_Zip_Code": "provider_zipcode","apc": "apc","Hospital_Referral_Region": "hospital_referral_region","Outpatient_Services": "outpatient_services","Average_Estimated_Submitted_Charges": "average_estimated_submitted_charges","Average_Total_Payments": "average_total_payments"}
           PIPELINE_NAME: "outpatient_charges_2014"
-
-        # Set resource limits for the pod here. For resource units in Kubernetes, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
         resources:
           limit_memory: "4G"
           limit_cpu: "1"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
-
       args:
         task_id: "load_outpatient_2011_to_bq"
-
-        # The GCS bucket where the CSV file is located in.
         bucket: "{{ var.value.composer_bucket }}"
-
-        # The GCS object path for the CSV file
         source_objects: ["data/cms_medicare/outpatient_charges_2011/data_output.csv"]
         source_format: "CSV"
         destination_project_dataset_table: "cms_medicare.outpatient_charges_2011"
-
-        # Use this if your CSV file contains a header row
         skip_leading_rows: 1
-
-        # How to write data to the table: overwrite, append, or write if empty
-        # See https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
         write_disposition: "WRITE_TRUNCATE"
-
-        # The BigQuery table schema based on the CSV file. For more info, see
-        # https://cloud.google.com/bigquery/docs/schemas.
-        # Always use snake_case and lowercase for column names, and be explicit,
-        # i.e. specify modes for all columns.
-        # types: "INTEGER", "TIMESTAMP", "STRING"
         schema_fields:
           - description: "The CMS Certification Number (CCN) of the provider billing for outpatient hospital services"
             name: "provider_id"
@@ -281,30 +195,14 @@ dag:
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
-
       args:
         task_id: "load_outpatient_2012_to_bq"
-
-        # The GCS bucket where the CSV file is located in.
         bucket: "{{ var.value.composer_bucket }}"
-
-        # The GCS object path for the CSV file
         source_objects: ["data/cms_medicare/outpatient_charges_2012/data_output.csv"]
         source_format: "CSV"
         destination_project_dataset_table: "cms_medicare.outpatient_charges_2012"
-
-        # Use this if your CSV file contains a header row
         skip_leading_rows: 1
-
-        # How to write data to the table: overwrite, append, or write if empty
-        # See https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
         write_disposition: "WRITE_TRUNCATE"
-
-        # The BigQuery table schema based on the CSV file. For more info, see
-        # https://cloud.google.com/bigquery/docs/schemas.
-        # Always use snake_case and lowercase for column names, and be explicit,
-        # i.e. specify modes for all columns.
-        # types: "INTEGER", "TIMESTAMP", "STRING"
         schema_fields:
           - description: "The CMS Certification Number (CCN) of the provider billing for outpatient hospital services"
             name: "provider_id"
@@ -353,30 +251,14 @@ dag:
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
-
       args:
         task_id: "load_outpatient_2013_to_bq"
-
-        # The GCS bucket where the CSV file is located in.
         bucket: "{{ var.value.composer_bucket }}"
-
-        # The GCS object path for the CSV file
         source_objects: ["data/cms_medicare/outpatient_charges_2013/data_output.csv"]
         source_format: "CSV"
         destination_project_dataset_table: "cms_medicare.outpatient_charges_2013"
-
-        # Use this if your CSV file contains a header row
         skip_leading_rows: 1
-
-        # How to write data to the table: overwrite, append, or write if empty
-        # See https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
         write_disposition: "WRITE_TRUNCATE"
-
-        # The BigQuery table schema based on the CSV file. For more info, see
-        # https://cloud.google.com/bigquery/docs/schemas.
-        # Always use snake_case and lowercase for column names, and be explicit,
-        # i.e. specify modes for all columns.
-        # types: "INTEGER", "TIMESTAMP", "STRING"
         schema_fields:
           - description: "The CMS Certification Number (CCN) of the provider billing for outpatient hospital services"
             name: "provider_id"
@@ -425,30 +307,14 @@ dag:
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
-
       args:
         task_id: "load_outpatient_2014_to_bq"
-
-        # The GCS bucket where the CSV file is located in.
         bucket: "{{ var.value.composer_bucket }}"
-
-        # The GCS object path for the CSV file
         source_objects: ["data/cms_medicare/outpatient_charges_2014/data_output.csv"]
         source_format: "CSV"
         destination_project_dataset_table: "cms_medicare.outpatient_charges_2014"
-
-        # Use this if your CSV file contains a header row
         skip_leading_rows: 1
-
-        # How to write data to the table: overwrite, append, or write if empty
-        # See https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
         write_disposition: "WRITE_TRUNCATE"
-
-        # The BigQuery table schema based on the CSV file. For more info, see
-        # https://cloud.google.com/bigquery/docs/schemas.
-        # Always use snake_case and lowercase for column names, and be explicit,
-        # i.e. specify modes for all columns.
-        # types: "INTEGER", "TIMESTAMP", "STRING"
         schema_fields:
           - description: "The CMS Certification Number (CCN) of the provider billing for outpatient hospital services"
             name: "provider_id"

--- a/datasets/covid19_cds_eu/dataset.yaml
+++ b/datasets/covid19_cds_eu/dataset.yaml
@@ -24,7 +24,3 @@ resources:
   - type: bigquery_dataset
     dataset_id: covid19_cds_eu
     description: COVID-19 CDS EU dataset
-  - type: storage_bucket
-    name: covid19-cds-eu
-    uniform_bucket_level_access: True
-    location: US

--- a/datasets/covid19_cds_eu/global_cases_by_province/pipeline.yaml
+++ b/datasets/covid19_cds_eu/global_cases_by_province/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "Global cases by province table"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: global_cases_by_province
     default_args:
@@ -38,16 +38,8 @@ dag:
         task_id: "global_cases_by_province_transform_csv"
         startup_timeout_seconds: 600
         name: "global_cases_by_province"
-        namespace: "default"
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: cloud.google.com/gke-nodepool
-                      operator: In
-                      values:
-                        - "pool-e2-standard-4"
+        namespace: "composer"
+        service_account_name: "datasets"
         image_pull_policy: "Always"
         image: "{{ var.json.covid19_cds_eu.container_registry.run_csv_transform_kub }}"
         env_vars:

--- a/datasets/covid19_google_mobility/mobility_report/mobility_report_dag.py
+++ b/datasets/covid19_google_mobility/mobility_report/mobility_report_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    mobility_report_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    mobility_report_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="mobility_report_transform_csv",
         startup_timeout_seconds=600,
         name="mobility_report",
@@ -51,11 +52,15 @@ with DAG(
             "CSV_HEADERS": '["country_region_code" ,"country_region" ,"sub_region_1" ,"sub_region_2" ,"metro_area" ,"iso_3166_2_code" ,"census_fips_code" ,"place_id" ,"date" ,"retail_and_recreation_percent_change_from_baseline" ,"grocery_and_pharmacy_percent_change_from_baseline" ,"parks_percent_change_from_baseline" ,"transit_stations_percent_change_from_baseline" ,"workplaces_percent_change_from_baseline" ,"residential_percent_change_from_baseline"]',
             "RENAME_MAPPINGS": '{"country_region_code":"country_region_code" ,"country_region":"country_region" ,"sub_region_1":"sub_region_1" ,"sub_region_2":"sub_region_2" ,"metro_area":"metro_area" ,"iso_3166_2_code":"iso_3166_2_code" ,"census_fips_code":"census_fips_code" ,"place_id":"place_id" ,"date":"date" ,"retail_and_recreation_percent_change_from_baseline":"retail_and_recreation_percent_change_from_baseline" ,"grocery_and_pharmacy_percent_change_from_baseline":"grocery_and_pharmacy_percent_change_from_baseline" ,"parks_percent_change_from_baseline":"parks_percent_change_from_baseline" ,"transit_stations_percent_change_from_baseline":"transit_stations_percent_change_from_baseline" ,"workplaces_percent_change_from_baseline":"workplaces_percent_change_from_baseline" ,"residential_percent_change_from_baseline":"residential_percent_change_from_baseline"}',
         },
-        resources={"request_memory": "2G", "request_cpu": "1"},
+        resources={
+            "request_memory": "8G",
+            "request_cpu": "2",
+            "request_ephemeral_storage": "10G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_mobility_report_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_mobility_report_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_mobility_report_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/covid19_google_mobility/mobility_report/data_output.csv"],

--- a/datasets/covid19_google_mobility/mobility_report/pipeline.yaml
+++ b/datasets/covid19_google_mobility/mobility_report/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "Terms of use By downloading or using the data, you agree to Google's Terms of Service: https://policies.google.com/terms Description This dataset aims to provide insights into what has changed in response to policies aimed at combating COVID-19. It reports movement trends over time by geography, across different categories of places such as retail and recreation, groceries and pharmacies, parks, transit stations, workplaces, and residential. This dataset is intended to help remediate the impact of COVID-19. It shouldn’t be used for medical diagnostic, prognostic, or treatment purposes. It also isn’t intended to be used for guidance on personal travel plans. To learn more about the dataset, the place categories and how we calculate these trends and preserve privacy, read the data documentation: https://www.google.com/covid19/mobility/data_documentation.html"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: mobility_report
     default_args:
@@ -40,7 +40,6 @@ dag:
         name: "mobility_report"
         namespace: "composer"
         service_account_name: "datasets"
-
         image_pull_policy: "Always"
         image: "{{ var.json.covid19_google_mobility.container_registry.run_csv_transform_kub }}"
         env_vars:
@@ -55,8 +54,9 @@ dag:
           RENAME_MAPPINGS: >-
             {"country_region_code":"country_region_code" ,"country_region":"country_region" ,"sub_region_1":"sub_region_1" ,"sub_region_2":"sub_region_2" ,"metro_area":"metro_area" ,"iso_3166_2_code":"iso_3166_2_code" ,"census_fips_code":"census_fips_code" ,"place_id":"place_id" ,"date":"date" ,"retail_and_recreation_percent_change_from_baseline":"retail_and_recreation_percent_change_from_baseline" ,"grocery_and_pharmacy_percent_change_from_baseline":"grocery_and_pharmacy_percent_change_from_baseline" ,"parks_percent_change_from_baseline":"parks_percent_change_from_baseline" ,"transit_stations_percent_change_from_baseline":"transit_stations_percent_change_from_baseline" ,"workplaces_percent_change_from_baseline":"workplaces_percent_change_from_baseline" ,"residential_percent_change_from_baseline":"residential_percent_change_from_baseline"}
         resources:
-          request_memory: "2G"
-          request_cpu: "1"
+          request_memory: "8G"
+          request_cpu: "2"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
@@ -68,7 +68,6 @@ dag:
         destination_project_dataset_table: "covid19_google_mobility.mobility_report"
         skip_leading_rows: 1
         write_disposition: "WRITE_TRUNCATE"
-
         schema_fields:
           - name: "country_region_code"
             type: "string"

--- a/datasets/covid19_govt_response/dataset.yaml
+++ b/datasets/covid19_govt_response/dataset.yaml
@@ -24,7 +24,3 @@ resources:
   - type: bigquery_dataset
     dataset_id: covid19_govt_response
     description: COVID-19 Govt Response dataset
-  - type: storage_bucket
-    name: covid19-govt-response
-    uniform_bucket_level_access: True
-    location: US

--- a/datasets/covid19_govt_response/oxford_policy_tracker/oxford_policy_tracker_dag.py
+++ b/datasets/covid19_govt_response/oxford_policy_tracker/oxford_policy_tracker_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,28 +34,12 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    oxford_policy_tracker_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    oxford_policy_tracker_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="oxford_policy_tracker_transform_csv",
         startup_timeout_seconds=600,
         name="oxford_policy_tracker",
-        namespace="default",
-        affinity={
-            "nodeAffinity": {
-                "requiredDuringSchedulingIgnoredDuringExecution": {
-                    "nodeSelectorTerms": [
-                        {
-                            "matchExpressions": [
-                                {
-                                    "key": "cloud.google.com/gke-nodepool",
-                                    "operator": "In",
-                                    "values": ["pool-e2-standard-4"],
-                                }
-                            ]
-                        }
-                    ]
-                }
-            }
-        },
+        namespace="composer",
+        service_account_name="datasets",
         image_pull_policy="Always",
         image="{{ var.json.covid19_govt_response.container_registry.run_csv_transform_kub }}",
         env_vars={
@@ -71,7 +56,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_oxford_policy_tracker_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_oxford_policy_tracker_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_oxford_policy_tracker_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=[

--- a/datasets/covid19_govt_response/oxford_policy_tracker/pipeline.yaml
+++ b/datasets/covid19_govt_response/oxford_policy_tracker/pipeline.yaml
@@ -20,7 +20,7 @@ resources:
     description: "Oxford policy tracker table"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: oxford_policy_tracker
     default_args:
@@ -38,16 +38,8 @@ dag:
         task_id: "oxford_policy_tracker_transform_csv"
         startup_timeout_seconds: 600
         name: "oxford_policy_tracker"
-        namespace: "default"
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: cloud.google.com/gke-nodepool
-                      operator: In
-                      values:
-                        - "pool-e2-standard-4"
+        namespace: "composer"
+        service_account_name: "datasets"
         image_pull_policy: "Always"
         image: "{{ var.json.covid19_govt_response.container_registry.run_csv_transform_kub }}"
         env_vars:
@@ -76,7 +68,6 @@ dag:
         skip_leading_rows: 1
         allow_quoted_newlines: True
         write_disposition: "WRITE_TRUNCATE"
-
         schema_fields:
           - name: "country_name"
             type: "string"

--- a/datasets/covid19_italy/data_by_province/data_by_province_dag.py
+++ b/datasets/covid19_italy/data_by_province/data_by_province_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    data_by_province_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    data_by_province_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="data_by_province_transform_csv",
         startup_timeout_seconds=600,
         name="covid19_italy_data_by_province",
@@ -55,7 +56,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_data_by_province_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_data_by_province_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_data_by_province_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/covid19_italy/data_by_province/data_output.csv"],

--- a/datasets/covid19_italy/data_by_province/pipeline.yaml
+++ b/datasets/covid19_italy/data_by_province/pipeline.yaml
@@ -24,7 +24,7 @@ resources:
 
 dag:
 
-  airflow_version: 1
+  airflow_version: 2
 
   initialize:
     dag_id: data_by_province

--- a/datasets/covid19_italy/data_by_region/data_by_region_dag.py
+++ b/datasets/covid19_italy/data_by_region/data_by_region_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    data_by_region_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    data_by_region_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="data_by_region_transform_csv",
         startup_timeout_seconds=600,
         name="covid19_italy_data_by_region",
@@ -55,7 +56,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_data_by_region_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_data_by_region_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_data_by_region_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/covid19_italy/data_by_region/data_output.csv"],

--- a/datasets/covid19_italy/data_by_region/pipeline.yaml
+++ b/datasets/covid19_italy/data_by_region/pipeline.yaml
@@ -24,7 +24,7 @@ resources:
 
 dag:
 
-  airflow_version: 1
+  airflow_version: 2
 
   initialize:
     dag_id: data_by_region

--- a/datasets/covid19_italy/national_trends/national_trends_dag.py
+++ b/datasets/covid19_italy/national_trends/national_trends_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    national_trends_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    national_trends_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="national_trends_transform_csv",
         startup_timeout_seconds=600,
         name="covid19_italy_national_trends",
@@ -55,7 +56,7 @@ with DAG(
     )
 
     # Task to load CSV data to a BigQuery table
-    load_national_trends_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_national_trends_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_national_trends_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/covid19_italy/national_trends/data_output.csv"],

--- a/datasets/covid19_italy/national_trends/pipeline.yaml
+++ b/datasets/covid19_italy/national_trends/pipeline.yaml
@@ -24,7 +24,7 @@ resources:
 
 dag:
 
-  airflow_version: 1
+  airflow_version: 2
 
   initialize:
     dag_id: national_trends

--- a/datasets/covid19_vaccination_access/vaccination_access_to_bq/pipeline.yaml
+++ b/datasets/covid19_vaccination_access/vaccination_access_to_bq/pipeline.yaml
@@ -28,7 +28,7 @@ resources:
     description: "This table represents the boundaries of areas surrounding vaccination facilities from which people can reach the facility by walking within predetermined time periods."
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: vaccination_access_to_bq
     default_args:

--- a/datasets/covid19_vaccination_access/vaccination_access_to_bq/vaccination_access_to_bq_dag.py
+++ b/datasets/covid19_vaccination_access/vaccination_access_to_bq/vaccination_access_to_bq_dag.py
@@ -14,7 +14,7 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +33,7 @@ with DAG(
 ) as dag:
 
     # Task to load CSV file from covid19-open-data bucket to facility_boundary_us_all
-    gcs_to_bq_table_us_all = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    gcs_to_bq_table_us_all = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="gcs_to_bq_table_us_all",
         bucket="{{ var.json.covid19_vaccination_access.source_bucket }}",
         source_objects=[
@@ -138,7 +138,7 @@ with DAG(
     )
 
     # Task to load CSV file from covid19-open-data bucket to facility_boundary_us_drive
-    gcs_to_bq_table_us_drive = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    gcs_to_bq_table_us_drive = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="gcs_to_bq_table_us_drive",
         bucket="{{ var.json.covid19_vaccination_access.source_bucket }}",
         source_objects=[
@@ -243,7 +243,7 @@ with DAG(
     )
 
     # Task to load CSV file from covid19-open-data bucket to facility_boundary_us_transit
-    gcs_to_bq_table_us_transit = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    gcs_to_bq_table_us_transit = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="gcs_to_bq_table_us_transit",
         bucket="{{ var.json.covid19_vaccination_access.source_bucket }}",
         source_objects=[
@@ -348,7 +348,7 @@ with DAG(
     )
 
     # Task to load CSV file from covid19-open-data bucket to facility_boundary_us_walk
-    gcs_to_bq_table_us_walk = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    gcs_to_bq_table_us_walk = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="gcs_to_bq_table_us_walk",
         bucket="{{ var.json.covid19_vaccination_access.source_bucket }}",
         source_objects=[

--- a/datasets/covid19_vaccination_search_insights/covid19_vaccination_search_insights/covid19_vaccination_search_insights_dag.py
+++ b/datasets/covid19_vaccination_search_insights/covid19_vaccination_search_insights/covid19_vaccination_search_insights_dag.py
@@ -14,7 +14,7 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +33,7 @@ with DAG(
 ) as dag:
 
     # Task to load global vaccination search insights CSV file from the covid19-open-data bucket to BQ
-    gcs_to_bq_vaccination_search_insights = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    gcs_to_bq_vaccination_search_insights = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="gcs_to_bq_vaccination_search_insights",
         bucket="{{ var.json.covid19_vaccination_search_insights.source_bucket }}",
         source_objects=[

--- a/datasets/covid19_vaccination_search_insights/covid19_vaccination_search_insights/pipeline.yaml
+++ b/datasets/covid19_vaccination_search_insights/covid19_vaccination_search_insights/pipeline.yaml
@@ -122,7 +122,7 @@ resources:
       ]
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: covid19_vaccination_search_insights
     default_args:

--- a/datasets/fda_food/food_enforcement/food_enforcement_dag.py
+++ b/datasets/fda_food/food_enforcement/food_enforcement_dag.py
@@ -56,7 +56,11 @@ with DAG(
             "RECORD_PATH": "",
             "META": '[ "status", "city", "state", "country", "classification",\n  "openfda", "product_type", "event_id", "recalling_firm", "address_1",\n  "address_2", "postal_code", "voluntary_mandated", "initial_firm_notification", "distribution_pattern",\n  "recall_number", "product_description", "product_quantity", "reason_for_recall", "recall_initiation_date",\n  "center_classification_date", "report_date", "code_info", "more_code_info", "termination_date" ]',
         },
-        resources={"limit_memory": "4G", "limit_cpu": "1"},
+        resources={
+            "request_memory": "4G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "5G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
@@ -65,7 +69,7 @@ with DAG(
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/fda_food/food_enforcement/files/data_output.csv"],
         source_format="CSV",
-        destination_project_dataset_table="{{ var.json.fda_food.container_registry.food_enforcement_destination_table }}",
+        destination_project_dataset_table="{{ var.json.fda_food.food_enforcement_destination_table }}",
         skip_leading_rows=1,
         allow_quoted_newlines=True,
         write_disposition="WRITE_TRUNCATE",

--- a/datasets/fda_food/food_enforcement/pipeline.yaml
+++ b/datasets/fda_food/food_enforcement/pipeline.yaml
@@ -82,8 +82,9 @@ dag:
               "recall_number", "product_description", "product_quantity", "reason_for_recall", "recall_initiation_date",
               "center_classification_date", "report_date", "code_info", "more_code_info", "termination_date" ]
         resources:
-          limit_memory: "4G"
-          limit_cpu: "1"
+          request_memory: "4G"
+          request_cpu: "1"
+          request_ephemeral_storage: "5G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
@@ -93,7 +94,7 @@ dag:
         bucket: "{{ var.value.composer_bucket }}"
         source_objects: ["data/fda_food/food_enforcement/files/data_output.csv"]
         source_format: "CSV"
-        destination_project_dataset_table: "{{ var.json.fda_food.container_registry.food_enforcement_destination_table }}"
+        destination_project_dataset_table: "{{ var.json.fda_food.food_enforcement_destination_table }}"
         skip_leading_rows: 1
         allow_quoted_newlines: True
         write_disposition: "WRITE_TRUNCATE"

--- a/datasets/fda_food/food_events/food_events_dag.py
+++ b/datasets/fda_food/food_events/food_events_dag.py
@@ -56,7 +56,11 @@ with DAG(
             "RECORD_PATH": "products",
             "META": '[\n  "report_number", "outcomes", "date_created", "reactions", "date_started",\n  ["consumer", "age"], ["consumer", "age_unit"], ["consumer", "gender"]\n]',
         },
-        resources={"limit_memory": "8G", "limit_cpu": "3"},
+        resources={
+            "request_memory": "4G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "5G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
@@ -65,7 +69,7 @@ with DAG(
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/fda_food/food_events/files/data_output.csv"],
         source_format="CSV",
-        destination_project_dataset_table="{{ var.json.fda_food.container_registry.food_events_destination_table }}",
+        destination_project_dataset_table="{{ var.json.fda_food.food_events_destination_table }}",
         skip_leading_rows=1,
         allow_quoted_newlines=True,
         field_delimiter=",",

--- a/datasets/fda_food/food_events/pipeline.yaml
+++ b/datasets/fda_food/food_events/pipeline.yaml
@@ -77,8 +77,9 @@ dag:
               ["consumer", "age"], ["consumer", "age_unit"], ["consumer", "gender"]
             ]
         resources:
-          limit_memory: "8G"
-          limit_cpu: "3"
+          request_memory: "4G"
+          request_cpu: "1"
+          request_ephemeral_storage: "5G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
@@ -88,7 +89,7 @@ dag:
         bucket: "{{ var.value.composer_bucket }}"
         source_objects: ["data/fda_food/food_events/files/data_output.csv"]
         source_format: "CSV"
-        destination_project_dataset_table: "{{ var.json.fda_food.container_registry.food_events_destination_table }}"
+        destination_project_dataset_table: "{{ var.json.fda_food.food_events_destination_table }}"
         skip_leading_rows: 1
         allow_quoted_newlines: True
         field_delimiter: ","

--- a/datasets/google_political_ads/advertiser_declared_stats/pipeline.yaml
+++ b/datasets/google_political_ads/advertiser_declared_stats/pipeline.yaml
@@ -23,7 +23,7 @@ resources:
     description: "Certain California and New Zealand advertisers are required to submit additional data about themselves. The advertiser is responsible for the accuracy of this information, which Google has not confirmed. For California, this information is provided from our express notification process required for certain California advertisers, which is separate from our verification process. For New Zealand, this information is provided during our verification process."
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: advertiser_declared_stats
     default_args:
@@ -78,6 +78,7 @@ dag:
         resources:
           request_memory: "2G"
           request_cpu: "1"
+          request_ephemeral_storage: "5G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/google_political_ads/advertiser_geo_spend/pipeline.yaml
+++ b/datasets/google_political_ads/advertiser_geo_spend/pipeline.yaml
@@ -23,7 +23,7 @@ resources:
     description: "This file contains total US advertiser spend on political ads, per US state and the District of Columbia."
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: advertiser_geo_spend
     default_args:
@@ -78,6 +78,7 @@ dag:
         resources:
           request_memory: "2G"
           request_cpu: "1"
+          request_ephemeral_storage: "5G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/google_political_ads/advertiser_stats/advertiser_stats_dag.py
+++ b/datasets/google_political_ads/advertiser_stats/advertiser_stats_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    advertiser_stats_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    advertiser_stats_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="advertiser_stats_transform_csv",
         startup_timeout_seconds=600,
         name="advertiser_stats",
@@ -52,11 +53,15 @@ with DAG(
             "CSV_HEADERS": '["advertiser_id","advertiser_name","public_ids_list","regions","elections","total_creatives","spend_usd","spend_eur","spend_inr","spend_bgn","spend_hrk","spend_czk","spend_dkk","spend_huf","spend_pln","spend_ron","spend_sek","spend_gbp","spend_nzd"]',
             "RENAME_MAPPINGS": '{"Advertiser_ID": "advertiser_id","Advertiser_Name": "advertiser_name","Public_IDs_List": "public_ids_list","Regions": "regions","Elections": "elections","Total_Creatives": "total_creatives","Spend_USD": "spend_usd","Spend_EUR": "spend_eur","Spend_INR": "spend_inr","Spend_BGN": "spend_bgn","Spend_HRK": "spend_hrk","Spend_CZK": "spend_czk","Spend_DKK": "spend_dkk","Spend_HUF": "spend_huf","Spend_PLN": "spend_pln","Spend_RON": "spend_ron","Spend_SEK": "spend_sek","Spend_GBP": "spend_gbp","Spend_NZD": "spend_nzd"}',
         },
-        resources={"request_memory": "2G", "request_cpu": "1"},
+        resources={
+            "request_memory": "2G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "5G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_advertiser_stats_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_advertiser_stats_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_advertiser_stats_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/google_political_ads/advertiser_stats/data_output.csv"],

--- a/datasets/google_political_ads/advertiser_stats/pipeline.yaml
+++ b/datasets/google_political_ads/advertiser_stats/pipeline.yaml
@@ -23,7 +23,7 @@ resources:
     description: "This table contains the information about advertisers who have run an election ad on Google Ads Services with at least one impression. The table's primary key is advertiser_id. This table relates to the others in this dataset, with the following connections between columns: advertiser_id is referenced from: advertiser_weekly_spend.advertiser_id campaign_targeting.advertiser_id creative_stats.advertiser_id advertiser_name is referenced from: advertiser_weekly_spend.advertiser_name campaign_targeting.advertiser_name advertiser_id.advertiser_name"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: advertiser_stats
     default_args:
@@ -78,6 +78,7 @@ dag:
         resources:
           request_memory: "2G"
           request_cpu: "1"
+          request_ephemeral_storage: "5G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/google_political_ads/advertiser_weekly_spend/advertiser_weekly_spend_dag.py
+++ b/datasets/google_political_ads/advertiser_weekly_spend/advertiser_weekly_spend_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    advertiser_weekly_spend_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    advertiser_weekly_spend_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="advertiser_weekly_spend_transform_csv",
         startup_timeout_seconds=600,
         name="advertiser_weekly_spend",
@@ -52,11 +53,15 @@ with DAG(
             "CSV_HEADERS": '["advertiser_id","advertiser_name","election_cycle","week_start_date","spend_usd","spend_eur","spend_inr","spend_bgn","spend_hrk","spend_czk","spend_dkk","spend_huf","spend_pln","spend_ron","spend_sek","spend_gbp","spend_nzd"]',
             "RENAME_MAPPINGS": '{"Advertiser_ID": "advertiser_id","Advertiser_Name": "advertiser_name","Election_Cycle": "election_cycle","Week_Start_Date": "week_start_date","Spend_USD": "spend_usd","Spend_EUR": "spend_eur","Spend_INR": "spend_inr","Spend_BGN": "spend_bgn","Spend_HRK": "spend_hrk","Spend_CZK": "spend_czk","Spend_DKK": "spend_dkk","Spend_HUF": "spend_huf","Spend_PLN": "spend_pln","Spend_RON": "spend_ron","Spend_SEK": "spend_sek","Spend_GBP": "spend_gbp","Spend_NZD": "spend_nzd"}',
         },
-        resources={"request_memory": "2G", "request_cpu": "1"},
+        resources={
+            "request_memory": "2G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "5G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_advertiser_weekly_spend_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_advertiser_weekly_spend_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_advertiser_weekly_spend_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=[

--- a/datasets/google_political_ads/advertiser_weekly_spend/pipeline.yaml
+++ b/datasets/google_political_ads/advertiser_weekly_spend/pipeline.yaml
@@ -23,7 +23,7 @@ resources:
     description: "This table contains the information for how much an advertiser spent on political ads during a given week. The table's primary key is advertiser_id, election_cycle, week_start_date"
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: advertiser_weekly_spend
     default_args:
@@ -79,6 +79,7 @@ dag:
         resources:
           request_memory: "2G"
           request_cpu: "1"
+          request_ephemeral_storage: "5G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/google_political_ads/campaign_targeting/pipeline.yaml
+++ b/datasets/google_political_ads/campaign_targeting/pipeline.yaml
@@ -23,7 +23,7 @@ resources:
     description: "This table was deprecated and ad-level targeting information was made available in the `google_political_ads.creative_stats` BigQuery table, effective April 2020. This table contains the information related to ad campaigns run by advertisers."
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: campaign_targeting
     default_args:
@@ -79,6 +79,7 @@ dag:
         resources:
           request_memory: "2G"
           request_cpu: "1"
+          request_ephemeral_storage: "5G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/google_political_ads/creative_stats/creative_stats_dag.py
+++ b/datasets/google_political_ads/creative_stats/creative_stats_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    creative_stats_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    creative_stats_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="creative_stats_transform_csv",
         startup_timeout_seconds=600,
         name="creative_stats",
@@ -52,11 +53,15 @@ with DAG(
             "CSV_HEADERS": '["ad_id","ad_url","ad_type","regions","advertiser_id","advertiser_name","ad_campaigns_list","date_range_start","date_range_end","num_of_days","impressions","spend_usd","first_served_timestamp","last_served_timestamp","age_targeting","gender_targeting","geo_targeting_included","geo_targeting_excluded","spend_range_min_usd","spend_range_max_usd","spend_range_min_eur","spend_range_max_eur","spend_range_min_inr","spend_range_max_inr","spend_range_min_bgn","spend_range_max_bgn","spend_range_min_hrk","spend_range_max_hrk","spend_range_min_czk","spend_range_max_czk","spend_range_min_dkk","spend_range_max_dkk","spend_range_min_huf","spend_range_max_huf","spend_range_min_pln","spend_range_max_pln","spend_range_min_ron","spend_range_max_ron","spend_range_min_sek","spend_range_max_sek","spend_range_min_gbp","spend_range_max_gbp","spend_range_min_nzd","spend_range_max_nzd"]',
             "RENAME_MAPPINGS": '{"Ad_ID": "ad_id","Ad_URL": "ad_url","Ad_Type": "ad_type","Regions": "regions","Advertiser_ID": "advertiser_id","Advertiser_Name": "advertiser_name","Ad_Campaigns_List": "ad_campaigns_list","Date_Range_Start": "date_range_start","Date_Range_End": "date_range_end","Num_of_Days": "num_of_days","Impressions": "impressions","Spend_USD": "spend_usd","Spend_Range_Min_USD": "spend_range_min_usd","Spend_Range_Max_USD": "spend_range_max_usd","Spend_Range_Min_EUR": "spend_range_min_eur","Spend_Range_Max_EUR": "spend_range_max_eur","Spend_Range_Min_INR": "spend_range_min_inr","Spend_Range_Max_INR": "spend_range_max_inr","Spend_Range_Min_BGN": "spend_range_min_bgn","Spend_Range_Max_BGN": "spend_range_max_bgn","Spend_Range_Min_HRK": "spend_range_min_hrk","Spend_Range_Max_HRK": "spend_range_max_hrk","Spend_Range_Min_CZK": "spend_range_min_czk","Spend_Range_Max_CZK": "spend_range_max_czk","Spend_Range_Min_DKK": "spend_range_min_dkk","Spend_Range_Max_DKK": "spend_range_max_dkk","Spend_Range_Min_HUF": "spend_range_min_huf","Spend_Range_Max_HUF": "spend_range_max_huf","Spend_Range_Min_PLN": "spend_range_min_pln","Spend_Range_Max_PLN": "spend_range_max_pln","Spend_Range_Min_RON": "spend_range_min_ron","Spend_Range_Max_RON": "spend_range_max_ron","Spend_Range_Min_SEK": "spend_range_min_sek","Spend_Range_Max_SEK": "spend_range_max_sek","Spend_Range_Min_GBP": "spend_range_min_gbp","Spend_Range_Max_GBP": "spend_range_max_gbp","Spend_Range_Min_NZD": "spend_range_min_nzd","Spend_Range_Max_NZD": "spend_range_max_nzd","Age_Targeting": "age_targeting","Gender_Targeting": "gender_targeting","Geo_Targeting_Included": "geo_targeting_included","Geo_Targeting_Excluded": "geo_targeting_excluded","First_Served_Timestamp": "first_served_timestamp","Last_Served_Timestamp": "last_served_timestamp"}',
         },
-        resources={"request_memory": "2G", "request_cpu": "1"},
+        resources={
+            "request_memory": "8G",
+            "request_cpu": "2",
+            "request_ephemeral_storage": "10G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_creative_stats_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_creative_stats_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_creative_stats_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/google_political_ads/creative_stats/data_output.csv"],
@@ -128,7 +133,7 @@ with DAG(
             {
                 "name": "impressions",
                 "type": "string",
-                "description": "Number of impressions for the election ad. Impressions are grouped into several buckets ≤ 10k 10k–100k 100k–1M 1M–10M > 10M.",
+                "description": "Number of impressions for the election ad. Impressions are grouped into several buckets ≤ 10k 10k-100k 100k-1M 1M-10M > 10M.",
                 "mode": "nullable",
             },
             {

--- a/datasets/google_political_ads/creative_stats/pipeline.yaml
+++ b/datasets/google_political_ads/creative_stats/pipeline.yaml
@@ -23,7 +23,7 @@ resources:
     description: "This table contains the information for election ads that have appeared on Google Ads Services. Ad-level targeting data was added to this file in April 2020. ad_id is referenced from: campaign_targeting.ads_list Data that was previously available in the `google_political_ads.campaign_targeting` table has been deprecated and removed in favor of this table."
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: creative_stats
     default_args:
@@ -76,8 +76,9 @@ dag:
             {"Ad_ID": "ad_id","Ad_URL": "ad_url","Ad_Type": "ad_type","Regions": "regions","Advertiser_ID": "advertiser_id","Advertiser_Name": "advertiser_name","Ad_Campaigns_List": "ad_campaigns_list","Date_Range_Start": "date_range_start","Date_Range_End": "date_range_end","Num_of_Days": "num_of_days","Impressions": "impressions","Spend_USD": "spend_usd","Spend_Range_Min_USD": "spend_range_min_usd","Spend_Range_Max_USD": "spend_range_max_usd","Spend_Range_Min_EUR": "spend_range_min_eur","Spend_Range_Max_EUR": "spend_range_max_eur","Spend_Range_Min_INR": "spend_range_min_inr","Spend_Range_Max_INR": "spend_range_max_inr","Spend_Range_Min_BGN": "spend_range_min_bgn","Spend_Range_Max_BGN": "spend_range_max_bgn","Spend_Range_Min_HRK": "spend_range_min_hrk","Spend_Range_Max_HRK": "spend_range_max_hrk","Spend_Range_Min_CZK": "spend_range_min_czk","Spend_Range_Max_CZK": "spend_range_max_czk","Spend_Range_Min_DKK": "spend_range_min_dkk","Spend_Range_Max_DKK": "spend_range_max_dkk","Spend_Range_Min_HUF": "spend_range_min_huf","Spend_Range_Max_HUF": "spend_range_max_huf","Spend_Range_Min_PLN": "spend_range_min_pln","Spend_Range_Max_PLN": "spend_range_max_pln","Spend_Range_Min_RON": "spend_range_min_ron","Spend_Range_Max_RON": "spend_range_max_ron","Spend_Range_Min_SEK": "spend_range_min_sek","Spend_Range_Max_SEK": "spend_range_max_sek","Spend_Range_Min_GBP": "spend_range_min_gbp","Spend_Range_Max_GBP": "spend_range_max_gbp","Spend_Range_Min_NZD": "spend_range_min_nzd","Spend_Range_Max_NZD": "spend_range_max_nzd","Age_Targeting": "age_targeting","Gender_Targeting": "gender_targeting","Geo_Targeting_Included": "geo_targeting_included","Geo_Targeting_Excluded": "geo_targeting_excluded","First_Served_Timestamp": "first_served_timestamp","Last_Served_Timestamp": "last_served_timestamp"}
         # Set resource limits for the pod here. For resource units in Kubernetes, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
         resources:
-          request_memory: "2G"
-          request_cpu: "1"
+          request_memory: "8G"
+          request_cpu: "2"
+          request_ephemeral_storage: "10G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"
@@ -148,7 +149,7 @@ dag:
             mode: "nullable"
           - name: "impressions"
             type: "string"
-            description: "Number of impressions for the election ad. Impressions are grouped into several buckets ≤ 10k 10k–100k 100k–1M 1M–10M > 10M."
+            description: "Number of impressions for the election ad. Impressions are grouped into several buckets ≤ 10k 10k-100k 100k-1M 1M-10M > 10M."
             mode: "nullable"
           - name: "spend_usd"
             type: "string"

--- a/datasets/google_political_ads/geo_spend/geo_spend_dag.py
+++ b/datasets/google_political_ads/geo_spend/geo_spend_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    geo_spend_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    geo_spend_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="geo_spend_transform_csv",
         startup_timeout_seconds=600,
         name="geo_spend",
@@ -52,11 +53,15 @@ with DAG(
             "CSV_HEADERS": '["country","country_subdivision_primary","country_subdivision_secondary","spend_usd","spend_eur","spend_inr","spend_bgn","spend_hrk","spend_czk","spend_dkk","spend_huf","spend_pln","spend_ron","spend_sek","spend_gbp","spend_nzd"]',
             "RENAME_MAPPINGS": '{"Country": "country","Country_Subdivision_Primary": "country_subdivision_primary","Country_Subdivision_Secondary": "country_subdivision_secondary","Spend_USD": "spend_usd","Spend_EUR": "spend_eur","Spend_INR": "spend_inr","Spend_BGN": "spend_bgn","Spend_HRK": "spend_hrk","Spend_CZK": "spend_czk","Spend_DKK": "spend_dkk","Spend_HUF": "spend_huf","Spend_PLN": "spend_pln","Spend_RON": "spend_ron","Spend_SEK": "spend_sek","Spend_GBP": "spend_gbp","Spend_NZD": "spend_nzd"}',
         },
-        resources={"request_memory": "2G", "request_cpu": "1"},
+        resources={
+            "request_memory": "2G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "5G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_geo_spend_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_geo_spend_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_geo_spend_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=["data/google_political_ads/geo_spend/data_output.csv"],

--- a/datasets/google_political_ads/geo_spend/pipeline.yaml
+++ b/datasets/google_political_ads/geo_spend/pipeline.yaml
@@ -23,7 +23,7 @@ resources:
     description: "This table contains the information for how much is spent buying election ads on Google Ads Services. The data is aggregated by Congressional district. The primary key is state, congressional_district."
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: geo_spend
     default_args:
@@ -79,6 +79,7 @@ dag:
         resources:
           request_memory: "2G"
           request_cpu: "1"
+          request_ephemeral_storage: "5G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/google_political_ads/last_updated/pipeline.yaml
+++ b/datasets/google_political_ads/last_updated/pipeline.yaml
@@ -23,7 +23,7 @@ resources:
     description: "This table contains the information of the latest updated date for the Political Ads report. All dates provided are per UTC time zone."
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: last_updated
     default_args:
@@ -79,6 +79,7 @@ dag:
         resources:
           request_memory: "2G"
           request_cpu: "1"
+          request_ephemeral_storage: "5G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/google_political_ads/top_keywords_history/pipeline.yaml
+++ b/datasets/google_political_ads/top_keywords_history/pipeline.yaml
@@ -23,7 +23,7 @@ resources:
     description: "The “Top Keywords” section of the US report was removed and updates to this table were terminated in December 2019. The table reflects historical data. This table contains the information for the top six keywords on which political advertisers have spent money during an election cycle. This data is only provided for US elections. The primary key is election_cycle, report_date."
 
 dag:
-  airflow_version: 1
+  airflow_version: 2
   initialize:
     dag_id: top_keywords_history
     default_args:
@@ -79,6 +79,7 @@ dag:
         resources:
           request_memory: "2G"
           request_cpu: "1"
+          request_ephemeral_storage: "5G"
 
     - operator: "GoogleCloudStorageToBigQueryOperator"
       description: "Task to load CSV data to a BigQuery table"

--- a/datasets/google_political_ads/top_keywords_history/top_keywords_history_dag.py
+++ b/datasets/google_political_ads/top_keywords_history/top_keywords_history_dag.py
@@ -14,7 +14,8 @@
 
 
 from airflow import DAG
-from airflow.contrib.operators import gcs_to_bq, kubernetes_pod_operator
+from airflow.providers.cncf.kubernetes.operators import kubernetes_pod
+from airflow.providers.google.cloud.transfers import gcs_to_bigquery
 
 default_args = {
     "owner": "Google",
@@ -33,7 +34,7 @@ with DAG(
 ) as dag:
 
     # Run CSV transform within kubernetes pod
-    top_keywords_history_transform_csv = kubernetes_pod_operator.KubernetesPodOperator(
+    top_keywords_history_transform_csv = kubernetes_pod.KubernetesPodOperator(
         task_id="top_keywords_history_transform_csv",
         startup_timeout_seconds=600,
         name="top_keywords_history",
@@ -52,11 +53,15 @@ with DAG(
             "CSV_HEADERS": '["election_cycle","report_date","keyword_1","spend_usd_1","keyword_2","spend_usd_2","keyword_3","spend_usd_3","keyword_4","spend_usd_4","keyword_5","spend_usd_5","keyword_6","spend_usd_6","region","elections"]',
             "RENAME_MAPPINGS": '{"Election_Cycle": "election_cycle","Report_Date": "report_date","Keyword_1": "keyword_1","Spend_USD_1": "spend_usd_1","Keyword_2": "keyword_2","Spend_USD_2": "spend_usd_2","Keyword_3": "keyword_3","Spend_USD_3": "spend_usd_3","Keyword_4": "keyword_4","Spend_USD_4": "spend_usd_4","Keyword_5": "keyword_5","Spend_USD_5": "spend_usd_5","Keyword_6": "keyword_6","Spend_USD_6": "spend_usd_6","Region": "region","Elections": "elections"}',
         },
-        resources={"request_memory": "2G", "request_cpu": "1"},
+        resources={
+            "request_memory": "2G",
+            "request_cpu": "1",
+            "request_ephemeral_storage": "5G",
+        },
     )
 
     # Task to load CSV data to a BigQuery table
-    load_top_keywords_history_to_bq = gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
+    load_top_keywords_history_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_top_keywords_history_to_bq",
         bucket="{{ var.value.composer_bucket }}",
         source_objects=[


### PR DESCRIPTION
## Description

This PR upgrades pipelines to use the Airflow 2 versions of their operators.

Due to the Composer 2 pods having a storage limit of only 10GB (and unfortunately defaults to 1GB) of storage, I've also explicitly set `request_ephemeral_storage` under `resources` for these operators.

## Checklist

- [x] Please merge this PR for me once it is approved.
- [x] If this PR adds or edits a dataset or pipeline, it was reviewed and approved by the Google Cloud Public Datasets team beforehand.
- [x] This PR is appropriately labeled.
