### PR TITLE
docs: Use `Pipfile.lock` and run tests for environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,20 @@ We use Pipenv to make environment setup more deterministic and uniform across di
 With Pipenv installed, run the following command to install the dependencies:
 
 ```bash
-pipenv install --dev
+pipenv install --ignore-pipfile --dev
 ```
 
-This uses the `Pipfile.lock` found in the project root and installs all the development dependencies.
+This installs dependencies using the specific versions in the `Pipfile.lock` file (instead of the `Pipfile` file which is ignored via `--ignore-pipfile`).
 
 Finally, initialize the Airflow database:
 
 ```bash
 pipenv run airflow db init
+```
+
+To ensure you have a proper setup, run the tests:
+```
+$ pipenv run python -m pytest -v
 ```
 
 # Building Data Pipelines


### PR DESCRIPTION
## Description

Enforce using the versions specified in `Pipfile.lock` and adds instructions on running tests for the environment setup section.

## Checklist

Note: If an item applies to you, all of its sub-items must be fulfilled

- [ ] **(Required)** This pull request is appropriately labeled
- [ ] Please merge this pull request after it's approved
- [ ] I'm adding or editing a feature
  - [ ] I have updated the [`README`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/blob/main/README.md) accordingly
  - [ ] I have added tests for the feature
- [ ] I'm adding or editing a dataset
  - [ ] The [Google Cloud Datasets team](mailto:cloud-datasets-onboarding@google.com) is aware of the proposed dataset
  - [ ] I put all my code inside  `datasets/<DATASET_NAME>` and nothing outside of that directory
- [ ] I'm adding/editing documentation
- [ ] I'm submitting a bugfix
  - [ ] I have added tests to my bugfix (see the [`tests`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/tree/main/tests) folder)
- [ ] I'm refactoring or cleaning up some code
