### PR TITLE
chore: Bump `black` version due to `click` dependency issue

### DIFF
--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -12,8 +12,8 @@ jobs:
           python -m pip install flake8 isort nbqa
       - uses: psf/black@stable
         with:
-          args: ". --check"
-          version: "21.5b1"
+          options: "--check"
+          version: "22.3.0"
       - name: Run Flake8 Linter
         run: flake8
       - name: Run isort

--- a/datasets/google_political_ads/pipelines/_images/run_csv_transform_kub/csv_transform.py
+++ b/datasets/google_political_ads/pipelines/_images/run_csv_transform_kub/csv_transform.py
@@ -124,7 +124,7 @@ def save_to_new_file(df: pd.DataFrame, file_path: str, table_name: str) -> None:
 def upload_file_to_gcs(file_path: pathlib.Path, gcs_bucket: str, gcs_path: str) -> None:
     storage_client = storage.Client()
     bucket = storage_client.bucket(gcs_bucket)
-    blob = bucket.blob(gcs_path, chunk_size=1000 * (2 ** 18))
+    blob = bucket.blob(gcs_path, chunk_size=1000 * pow(2, 18))
     blob.upload_from_filename(file_path)
 
 


### PR DESCRIPTION
## Description

This PR implements a fix from https://github.com/psf/black/issues/2964#issuecomment-1080974737. 

There's a recent breakage of the Python linter due to the `click` dependency getting updated. It's now patched by `black` contributors.

## Checklist

Note: If an item applies to you, all of its sub-items must be fulfilled

- [ ] **(Required)** This pull request is appropriately labeled
- [ ] Please merge this pull request after it's approved
- [ ] I'm adding or editing a feature
  - [ ] I have updated the [`README`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/blob/main/README.md) accordingly
  - [ ] I have added tests for the feature
- [ ] I'm adding or editing a dataset
  - [ ] The [Google Cloud Datasets team](mailto:cloud-datasets-onboarding@google.com) is aware of the proposed dataset
  - [ ] I put all my code inside  `datasets/<DATASET_NAME>` and nothing outside of that directory
- [ ] I'm adding/editing documentation
- [ ] I'm submitting a bugfix
  - [ ] I have added tests to my bugfix (see the [`tests`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/tree/main/tests) folder)
- [ ] I'm refactoring or cleaning up some code
