### PR TITLE
fix: Fix generating BQ views for IDC dataset

### DIFF
--- a/datasets/idc/pipelines/_images/generate_bq_views/script.py
+++ b/datasets/idc/pipelines/_images/generate_bq_views/script.py
@@ -51,14 +51,17 @@ def main(
             source_view = client.get_table(
                 f"{source_project}.{dataset}.{table.table_id}"
             )
-            create_or_update_view(client, source_view, target_project)
+            create_or_update_view(client, source_view, source_project, target_project)
             source_views.append(table.table_id)
 
         sync_views(client, dataset, source_views, target_project)
 
 
 def create_or_update_view(
-    client: bigquery.Client, source_view: bigquery.Table, target_project: str
+    client: bigquery.Client,
+    source_view: bigquery.Table,
+    source_project: str,
+    target_project: str,
 ) -> None:
     try:
         target_view = client.get_table(
@@ -71,7 +74,7 @@ def create_or_update_view(
         f"{target_project}.{source_view.dataset_id}.{source_view.table_id}"
     )
     _view.description = source_view.description
-    _view.view_query = source_view.view_query
+    _view.view_query = source_view.view_query.replace(source_project, target_project)
 
     # Create the view if it doesn't exist. Otherwise, update it.
     if not target_view:


### PR DESCRIPTION
## Description

Fixes a bug for the IDC dataset where the generated BQ views should use the `bigquery-public-data` project .

## Checklist

Note: If an item applies to you, all of its sub-items must be fulfilled

- [x] **(Required)** This pull request is appropriately labeled
- [x] Please merge this pull request after it's approved
- [ ] I'm adding or editing a feature
  - [ ] I have updated the [`README`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/blob/main/README.md) accordingly
  - [ ] I have added tests for the feature
- [x] I'm adding or editing a dataset
  - [x] The [Google Cloud Datasets team](mailto:cloud-datasets-onboarding@google.com) is aware of the proposed dataset
  - [x] I put all my code inside  `datasets/<DATASET_NAME>` and nothing outside of that directory
- [ ] I'm adding/editing documentation
- [ ] I'm submitting a bugfix
  - [ ] I have added tests to my bugfix (see the [`tests`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/tree/main/tests) folder)
- [ ] I'm refactoring or cleaning up some code
