### PR TITLE
chore: Use dynamic IAM permissions for Open Targets

### DIFF
--- a/datasets/open_targets/infra/open_targets_dataset.tf
+++ b/datasets/open_targets/infra/open_targets_dataset.tf
@@ -21,6 +21,20 @@ resource "google_bigquery_dataset" "open_targets_platform" {
   description = "Open-Targets dataset"
 }
 
+data "google_iam_policy" "bq_ds__open_targets_platform" {
+  dynamic "binding" {
+    for_each = var.iam_policies["bigquery_datasets"]["open_targets_platform"]
+    content {
+      role    = binding.value["role"]
+      members = binding.value["members"]
+    }
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "open_targets_platform" {
+  dataset_id  = google_bigquery_dataset.open_targets_platform.dataset_id
+  policy_data = data.google_iam_policy.bq_ds__open_targets_platform.policy_data
+}
 output "bigquery_dataset-open_targets_platform-dataset_id" {
   value = google_bigquery_dataset.open_targets_platform.dataset_id
 }
@@ -31,6 +45,20 @@ resource "google_bigquery_dataset" "open_targets_genetics" {
   description = "Open-Targets-Genetics dataset"
 }
 
+data "google_iam_policy" "bq_ds__open_targets_genetics" {
+  dynamic "binding" {
+    for_each = var.iam_policies["bigquery_datasets"]["open_targets_genetics"]
+    content {
+      role    = binding.value["role"]
+      members = binding.value["members"]
+    }
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "open_targets_genetics" {
+  dataset_id  = google_bigquery_dataset.open_targets_genetics.dataset_id
+  policy_data = data.google_iam_policy.bq_ds__open_targets_genetics.policy_data
+}
 output "bigquery_dataset-open_targets_genetics-dataset_id" {
   value = google_bigquery_dataset.open_targets_genetics.dataset_id
 }


### PR DESCRIPTION
## Description

Allows custom IAM privileges for Open Targets (used for development).

## Checklist

Note: If an item applies to you, all of its sub-items must be fulfilled

- [ ] **(Required)** This pull request is appropriately labeled
- [ ] Please merge this pull request after it's approved
- [ ] I'm adding or editing a feature
  - [ ] I have updated the [`README`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/blob/main/README.md) accordingly
  - [ ] I have added tests for the feature
- [ ] I'm adding or editing a dataset
  - [ ] The [Google Cloud Datasets team](mailto:cloud-datasets-onboarding@google.com) is aware of the proposed dataset
  - [ ] I put all my code inside  `datasets/<DATASET_NAME>` and nothing outside of that directory
- [ ] I'm adding/editing documentation
- [ ] I'm submitting a bugfix
  - [ ] I have added tests to my bugfix (see the [`tests`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/tree/main/tests) folder)
- [ ] I'm refactoring or cleaning up some code
