### PR TITLE
fix: Use Python 3.8.12 for Airflow 1 tests

### DIFF
--- a/.github/workflows/unit-tests-airflow1.yaml
+++ b/.github/workflows/unit-tests-airflow1.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8.12]
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v2


### PR DESCRIPTION
## Description

Fixes Airflow 1 tests using Python 3.8.13 by making the version more specific to 3.8.12 (as per `poetry.lock`)

## Checklist

Note: If an item applies to you, all of its sub-items must be fulfilled

- [x] **(Required)** This pull request is appropriately labeled
- [x] Please merge this pull request after it's approved
- [x] I'm submitting a bugfix
