### PR TITLE
fix: Add table partitions to cloud_storage_geo_index

### DIFF
--- a/datasets/cloud_storage_geo_index/infra/cloud_storage_geo_index_pipeline.tf
+++ b/datasets/cloud_storage_geo_index/infra/cloud_storage_geo_index_pipeline.tf
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+resource "google_bigquery_table" "cloud_storage_geo_index_landsat_index" {
+  project     = var.project_id
+  dataset_id  = "cloud_storage_geo_index"
+  table_id    = "landsat_index"
+  description = "Landsat index table"
+  time_partitioning {
+    type = "MONTH"
+
+    field = "sensing_time"
+
+    require_partition_filter = false
+  }
+  clustering          = ["spacecraft_id", "sensor_id", "wrs_path", "wrs_row"]
+  deletion_protection = true
+  depends_on = [
+    google_bigquery_dataset.cloud_storage_geo_index
+  ]
+}
+
+output "bigquery_table-cloud_storage_geo_index_landsat_index-table_id" {
+  value = google_bigquery_table.cloud_storage_geo_index_landsat_index.table_id
+}
+
+output "bigquery_table-cloud_storage_geo_index_landsat_index-id" {
+  value = google_bigquery_table.cloud_storage_geo_index_landsat_index.id
+}
+
+resource "google_bigquery_table" "cloud_storage_geo_index_sentinel_2_index" {
+  project     = var.project_id
+  dataset_id  = "cloud_storage_geo_index"
+  table_id    = "sentinel_2_index"
+  description = "Sentinel 2 table"
+  time_partitioning {
+    type = "MONTH"
+
+    field = "sensing_time"
+
+    require_partition_filter = false
+  }
+  clustering = ["product_id", "mgrs_tile", "generation_time", "datatake_identifier"]
+  depends_on = [
+    google_bigquery_dataset.cloud_storage_geo_index
+  ]
+}
+
+output "bigquery_table-cloud_storage_geo_index_sentinel_2_index-table_id" {
+  value = google_bigquery_table.cloud_storage_geo_index_sentinel_2_index.table_id
+}
+
+output "bigquery_table-cloud_storage_geo_index_sentinel_2_index-id" {
+  value = google_bigquery_table.cloud_storage_geo_index_sentinel_2_index.id
+}

--- a/datasets/cloud_storage_geo_index/infra/variables.tf
+++ b/datasets/cloud_storage_geo_index/infra/variables.tf
@@ -20,4 +20,7 @@ variable "bucket_name_prefix" {}
 variable "impersonating_acct" {}
 variable "region" {}
 variable "env" {}
+variable "iam_policies" {
+  default = {}
+}
 

--- a/datasets/cloud_storage_geo_index/pipelines/cloud_storage_geo_index/pipeline.yaml
+++ b/datasets/cloud_storage_geo_index/pipelines/cloud_storage_geo_index/pipeline.yaml
@@ -16,10 +16,29 @@
 resources:
   - type: bigquery_table
     table_id: landsat_index
-    description: "Landsat_Index Dataset"
+    description: "Landsat index table"
+    time_partitioning:
+      type: MONTH
+      field: sensing_time
+      require_partition_filter: false
+    clustering:
+      - "spacecraft_id"
+      - "sensor_id"
+      - "wrs_path"
+      - "wrs_row"
+    deletion_protection: true
   - type: bigquery_table
     table_id: sentinel_2_index
-    description: "Sentinel_2_Index Dataset"
+    description: "Sentinel 2 table"
+    time_partitioning:
+      type: MONTH
+      field: sensing_time
+      require_partition_filter: false
+    clustering:
+      - "product_id"
+      - "mgrs_tile"
+      - "generation_time"
+      - "datatake_identifier"
 
 dag:
   airflow_version: 2


### PR DESCRIPTION
## Description

Adds table partitions to `cloud_storage_geo_index` tables to align with what's in production.

## Checklist

Note: If an item applies to you, all of its sub-items must be fulfilled

- [ ] **(Required)** This pull request is appropriately labeled
- [ ] Please merge this pull request after it's approved
- [ ] I'm adding or editing a dataset
  - [ ] The [Google Cloud Datasets team](mailto:cloud-datasets-onboarding@google.com) is aware of the proposed dataset
  - [ ] I put all my code inside  `datasets/<DATASET_NAME>` and nothing outside of that directory
- [ ] I'm submitting a bugfix
  - [ ] I have added tests to my bugfix (see the [`tests`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/tree/main/tests) folder)
