### PR TITLE
fix: Use proper GCS prefix for custom data folder

### DIFF
--- a/tests/scripts/test_deploy_dag.py
+++ b/tests/scripts/test_deploy_dag.py
@@ -720,7 +720,8 @@ def test_script_copy_files_in_data_folder_to_composer_with_folder_created(
 
     data_folder = pipeline_path / "data"
     data_folder.mkdir(parents=True)
-    assert data_folder.exists() and data_folder.is_dir()
+    (data_folder / "test_file.txt").touch()
+    assert data_folder.exists() and data_folder.is_dir() and any(data_folder.iterdir())
 
     airflow_version = 2
     mocker.patch("scripts.deploy_dag.check_and_configure_airflow_variables")


### PR DESCRIPTION
## Description

Fixes the GCS prefix where contents of the folder `datasets/DATASET/pipelines/data` should be uploaded to in the Composer bucket.

## Checklist

Note: If an item applies to you, all of its sub-items must be fulfilled

- [ ] **(Required)** This pull request is appropriately labeled
- [ ] Please merge this pull request after it's approved
- [ ] I'm submitting a bugfix
  - [ ] I have added/revised tests for my bugfix (see the [`tests`](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/tree/main/tests) folder)
