### PR TITLE
chore: Remove indentation warning for cloud_storage_geo_index YAML

### DIFF
--- a/datasets/cloud_storage_geo_index/pipelines/cloud_storage_geo_index/pipeline.yaml
+++ b/datasets/cloud_storage_geo_index/pipelines/cloud_storage_geo_index/pipeline.yaml
@@ -30,7 +30,7 @@ dag:
       depends_on_past: False
       start_date: '2021-03-01'
     max_active_runs: 1
-    schedule_interval: "* 1 * * 6" # 06:00 on Monday
+    schedule_interval: "* 1 * * 6"  # 06:00 on Monday
     catchup: False
     default_view: graph
 


### PR DESCRIPTION
Removes the "too few spaces before comment" warnings in other pull requests.

## Checklist

- [x] **(Required)** This pull request is appropriately labeled
- [x] Please merge this pull request after it's approved