### PR TITLE
Fix: Resolve Cluster Name Mismatch In Census Bureau ACS Dataset

### DIFF
--- a/datasets/census_bureau_acs/pipelines/census_bureau_acs/census_bureau_acs_dag.py
+++ b/datasets/census_bureau_acs/pipelines/census_bureau_acs/census_bureau_acs_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -2860,7 +2860,7 @@ with DAG(
         task_id="delete_cluster",
         project_id="{{ var.value.gcp_project }}",
         location="us-central1-c",
-        name="census_bureau_acs",
+        name="census-bureau-acs",
     )
 
     (

--- a/datasets/census_bureau_acs/pipelines/census_bureau_acs/pipeline.yaml
+++ b/datasets/census_bureau_acs/pipelines/census_bureau_acs/pipeline.yaml
@@ -3561,7 +3561,7 @@ dag:
         task_id: "delete_cluster"
         project_id: "{{ var.value.gcp_project }}"
         location: "us-central1-c"
-        name: census_bureau_acs
+        name: census-bureau-acs
 
 
   graph_paths:


### PR DESCRIPTION
## Description

Name mismatch in pipeline.yaml cluster name

## Checklist

- [x] **(Required)** This pull request is appropriately labeled
- [x] Please merge this pull request after it's approved

Use the sections below based on what's applicable to your PR and delete the rest:

### Data Onboarding
- [x] I'm adding or editing a dataset
- [x] The [Google Cloud Datasets team](mailto:cloud-datasets-onboarding@google.com) is aware of the proposed dataset
- [x] I put all my code inside  `datasets/census_bureau_acs` and nothing outside of that directory
