### PR TITLE
Fix: Resolve Cluster Name Mismatch In The General Index Dataset.

### DIFF
--- a/datasets/the_general_index/pipelines/the_general_index/pipeline.yaml
+++ b/datasets/the_general_index/pipelines/the_general_index/pipeline.yaml
@@ -1717,7 +1717,7 @@ dag:
         task_id: "delete_cluster"
         project_id: "{{ var.value.gcp_project }}"
         location: "us-central1-c"
-        name: the_general_index
+        name: the-general-index
 
   graph_paths:
     - "create_cluster >> [ transform_csv_dump_0, transform_csv_dump_1, transform_csv_dump_2, transform_csv_dump_3, transform_csv_dump_4, transform_csv_dump_5, transform_csv_dump_6, transform_csv_dump_7, transform_csv_dump_8, transform_csv_dump_9, transform_csv_dump_a, transform_csv_dump_b, transform_csv_dump_c, transform_csv_dump_d, transform_csv_dump_e, transform_csv_dump_f ] >> delete_cluster"

--- a/datasets/the_general_index/pipelines/the_general_index/the_general_index_dag.py
+++ b/datasets/the_general_index/pipelines/the_general_index/the_general_index_dag.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -548,7 +548,7 @@ with DAG(
         task_id="delete_cluster",
         project_id="{{ var.value.gcp_project }}",
         location="us-central1-c",
-        name="the_general_index",
+        name="the-general-index",
     )
 
     (


### PR DESCRIPTION
## Description

Name mismatch in pipeline.yaml cluster name

## Checklist

- [x] **(Required)** This pull request is appropriately labeled
- [x] Please merge this pull request after it's approved

Use the sections below based on what's applicable to your PR and delete the rest:

### Data Onboarding
- [x] I'm adding or editing a dataset
- [x] The [Google Cloud Datasets team](mailto:cloud-datasets-onboarding@google.com) is aware of the proposed dataset
- [x] I put all my code inside  `datasets/the_general_index` and nothing outside of that directory
