### PR TITLE
Fix: Remove GKE cluster operator for dataset Census Opportunity Atlas

### DIFF
--- a/datasets/census_opportunity_atlas/infra/census_opportunity_atlas_dataset.tf
+++ b/datasets/census_opportunity_atlas/infra/census_opportunity_atlas_dataset.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
 resource "google_bigquery_dataset" "census_opportunity_atlas" {
   dataset_id  = "census_opportunity_atlas"
   project     = var.project_id
-  description = "Census Opportunity Atlas"
+  description = "Social mobility data for every Census tract in America."
 }
 
 output "bigquery_dataset-census_opportunity_atlas-dataset_id" {

--- a/datasets/census_opportunity_atlas/infra/census_opportunity_atlas_pipeline.tf
+++ b/datasets/census_opportunity_atlas/infra/census_opportunity_atlas_pipeline.tf
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+resource "google_bigquery_table" "census_opportunity_atlas_tract_covariates" {
+  project     = var.project_id
+  dataset_id  = "census_opportunity_atlas"
+  table_id    = "tract_covariates"
+  description = "Census Opportunity Atlas"
+  depends_on = [
+    google_bigquery_dataset.census_opportunity_atlas
+  ]
+}
+
+output "bigquery_table-census_opportunity_atlas_tract_covariates-table_id" {
+  value = google_bigquery_table.census_opportunity_atlas_tract_covariates.table_id
+}
+
+output "bigquery_table-census_opportunity_atlas_tract_covariates-id" {
+  value = google_bigquery_table.census_opportunity_atlas_tract_covariates.id
+}
+
+resource "google_bigquery_table" "census_opportunity_atlas_tract_outcomes" {
+  project     = var.project_id
+  dataset_id  = "census_opportunity_atlas"
+  table_id    = "tract_outcomes"
+  description = "Census Opportunity Atlas"
+  depends_on = [
+    google_bigquery_dataset.census_opportunity_atlas
+  ]
+}
+
+output "bigquery_table-census_opportunity_atlas_tract_outcomes-table_id" {
+  value = google_bigquery_table.census_opportunity_atlas_tract_outcomes.table_id
+}
+
+output "bigquery_table-census_opportunity_atlas_tract_outcomes-id" {
+  value = google_bigquery_table.census_opportunity_atlas_tract_outcomes.id
+}

--- a/datasets/census_opportunity_atlas/infra/provider.tf
+++ b/datasets/census_opportunity_atlas/infra/provider.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/datasets/census_opportunity_atlas/infra/variables.tf
+++ b/datasets/census_opportunity_atlas/infra/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Google LLC
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,4 +20,7 @@ variable "bucket_name_prefix" {}
 variable "impersonating_acct" {}
 variable "region" {}
 variable "env" {}
+variable "iam_policies" {
+  default = {}
+}
 

--- a/datasets/census_opportunity_atlas/pipelines/census_opportunity_atlas/pipeline.yaml
+++ b/datasets/census_opportunity_atlas/pipelines/census_opportunity_atlas/pipeline.yaml
@@ -17,6 +17,9 @@ resources:
   - type: bigquery_table
     table_id: tract_covariates
     description: "Census Opportunity Atlas"
+  - type: bigquery_table
+    table_id: tract_outcomes
+    description: "Census Opportunity Atlas"
 dag:
   airflow_version: 2
   initialize:
@@ -24,36 +27,20 @@ dag:
     default_args:
       owner: "Google"
       depends_on_past: False
-      start_date: '2021-03-01'
+      start_date: '2022-08-25'
     max_active_runs: 1
     schedule_interval: "@daily"
     catchup: False
     default_view: graph
   tasks:
-    - operator: "GKECreateClusterOperator"
-      args:
-        task_id: "create_cluster"
-        project_id: "{{ var.value.gcp_project }}"
-        location: "us-central1-c"
-        body:
-          name: census-opportunity-atlas
-          initial_node_count: 2
-          network: "{{ var.value.vpc_network }}"
-          node_config:
-            machine_type: e2-standard-16
-            oauth_scopes:
-              - https://www.googleapis.com/auth/devstorage.read_write
-              - https://www.googleapis.com/auth/cloud-platform
-    - operator: "GKEStartPodOperator"
-      description: "Run CSV transform within kubernetes pod"
+    - operator: "KubernetesPodOperator"
+      description: "Run CSV transform within the kubernetes pod"
       args:
         task_id: "tract_covariates"
         startup_timeout_seconds: 600
         name: "tract_covariates"
-        namespace: "default"
-        project_id: "{{ var.value.gcp_project }}"
-        location: "us-central1-c"
-        cluster_name: census-opportunity-atlas
+        namespace: "composer"
+        service_account_name: "datasets"
         image_pull_policy: "Always"
         image: "{{ var.json.census_opportunity_atlas.container_registry.tract_covariates.run_csv_transform_kub }}"
         env_vars:
@@ -195,15 +182,13 @@ dag:
         resources:
           request_ephemeral_storage: "8G"
           request_cpu: "1"
-    - operator: "GKEStartPodOperator"
-      description: "Run CSV transform within kubernetes pod"
+    - operator: "KubernetesPodOperator"
+      description: "Run CSV transform within the kubernetes pod"
       args:
         task_id: "tract_outcomes"
         name: "tract_outcomes"
-        namespace: "default"
-        project_id: "{{ var.value.gcp_project }}"
-        location: "us-central1-c"
-        cluster_name: census-opportunity-atlas
+        namespace: "composer"
+        service_account_name: "datasets"
         image_pull_policy: "Always"
         image: "{{ var.json.census_opportunity_atlas.container_registry.tract_outcomes.run_csv_transform_kub }}"
         env_vars:
@@ -228,11 +213,6 @@ dag:
         resources:
           request_ephemeral_storage: "8G"
           limit_cpu: "1"
-    - operator: "GKEDeleteClusterOperator"
-      args:
-        task_id: "delete_cluster"
-        project_id: "{{ var.value.gcp_project }}"
-        location: "us-central1-c"
-        name: census-opportunity-atlas
+
   graph_paths:
-    - "create_cluster >> [ tract_covariates, tract_outcomes ] >> delete_cluster"
+    - "tract_covariates, tract_outcomes"

--- a/datasets/census_opportunity_atlas/pipelines/dataset.yaml
+++ b/datasets/census_opportunity_atlas/pipelines/dataset.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+dataset:
+  name: census_opportunity_atlas
+  friendly_name: census_opportunity_atlas
+  description: Social mobility data for every Census tract in America.
+  dataset_sources: https://opportunityinsights.org
+  terms_of_use: ~
+
+
+resources:
+  - type: bigquery_dataset
+    dataset_id: census_opportunity_atlas
+    description: Social mobility data for every Census tract in America.


### PR DESCRIPTION
## Description

This pull request introduces 2 changes:
- replace GKE cluster operator with Pod operator
- add dataset.yaml file 

## Checklist

- [x] **(Required)** This pull request is appropriately labeled
- [x] Please merge this pull request after it's approved



### Data Onboarding
- [x] I'm adding or editing a dataset
- [x] The [Google Cloud Datasets team](mailto:cloud-datasets-onboarding@google.com) is aware of the proposed dataset
- [x] I put all my code inside  `datasets/census_opportunity_atlas` and nothing outside of that directory


### Code cleanup or refactoring
- [x] I'm refactoring or cleaning up some code
