### PR TITLE
Fix: Resolve Issue With Name Node Corruption In New york Dataset

### DIFF
--- a/datasets/new_york/pipelines/new_york/new_york_dag.py
+++ b/datasets/new_york/pipelines/new_york/new_york_dag.py
@@ -58,7 +58,7 @@ with DAG(
         cluster_name="new-york",
         namespace="default",
         image_pull_policy="Always",
-        image="{{ var.json.new_york.container_registry.ny_311_service_requests.run_csv_transform_kub }}",
+        image="{{ var.json.new_york.container_registry.run_csv_transform_kub_ny_311_service_requests }}",
         env_vars={
             "PIPELINE_NAME": "{{ var.json.new_york.ny_311_service_requests.pipeline_name }}",
             "SOURCE_URL": "{{ var.json.new_york.ny_311_service_requests.source_url }}",
@@ -89,7 +89,7 @@ with DAG(
         cluster_name="new-york",
         namespace="default",
         image_pull_policy="Always",
-        image="{{ var.json.new_york.container_registry.citibike_stations.run_csv_transform_kub }}",
+        image="{{ var.json.new_york.container_registry.run_csv_transform_kub_citibike_stations }}",
         env_vars={
             "PIPELINE_NAME": "{{ var.json.new_york.citibike_stations.pipeline_name }}",
             "SOURCE_URL_STATIONS_JSON": "{{ var.json.new_york.citibike_stations.source_url_stations }}",
@@ -124,7 +124,7 @@ with DAG(
         cluster_name="new-york",
         namespace="default",
         image_pull_policy="Always",
-        image="{{ var.json.new_york.container_registry.nypd_mv_collisions.run_csv_transform_kub }}",
+        image="{{ var.json.new_york.container_registry.run_csv_transform_kub_nypd_mv_collisions }}",
         env_vars={
             "PIPELINE_NAME": "{{ var.json.new_york.nypd_mv_collisions.pipeline_name }}",
             "SOURCE_URL": "{{ var.json.new_york.nypd_mv_collisions.source_url }}",
@@ -158,7 +158,7 @@ with DAG(
         cluster_name="new-york",
         namespace="default",
         image_pull_policy="Always",
-        image="{{ var.json.new_york.container_registry.tree_census_1995.run_csv_transform_kub }}",
+        image="{{ var.json.new_york.container_registry.run_csv_transform_kub_tree_census_1995 }}",
         env_vars={
             "PIPELINE_NAME": "{{ var.json.new_york.tree_census_1995.pipeline_name }}",
             "SOURCE_URL": "{{ var.json.new_york.tree_census_1995.source_url }}",

--- a/datasets/new_york/pipelines/new_york/new_york_dag.py
+++ b/datasets/new_york/pipelines/new_york/new_york_dag.py
@@ -36,7 +36,7 @@ with DAG(
         project_id="{{ var.value.gcp_project }}",
         location="us-central1-c",
         body={
-            "name": "new-york",
+            "name": "pubds-new-york",
             "initial_node_count": 4,
             "network": "{{ var.value.vpc_network }}",
             "ip_allocation_policy": {"cluster_ipv4_cidr_block": "/26"},
@@ -56,7 +56,7 @@ with DAG(
         name="311_service_requests",
         project_id="{{ var.value.gcp_project }}",
         location="us-central1-c",
-        cluster_name="new-york",
+        cluster_name="pubds-new-york",
         namespace="default",
         image_pull_policy="Always",
         image="{{ var.json.new_york.container_registry.run_csv_transform_kub_ny_311_service_requests }}",
@@ -87,7 +87,7 @@ with DAG(
         name="citibike_stations",
         project_id="{{ var.value.gcp_project }}",
         location="us-central1-c",
-        cluster_name="new-york",
+        cluster_name="pubds-new-york",
         namespace="default",
         image_pull_policy="Always",
         image="{{ var.json.new_york.container_registry.run_csv_transform_kub_citibike_stations }}",
@@ -122,7 +122,7 @@ with DAG(
         name="nypd_mv_collisions",
         project_id="{{ var.value.gcp_project }}",
         location="us-central1-c",
-        cluster_name="new-york",
+        cluster_name="pubds-new-york",
         namespace="default",
         image_pull_policy="Always",
         image="{{ var.json.new_york.container_registry.run_csv_transform_kub_nypd_mv_collisions }}",
@@ -156,7 +156,7 @@ with DAG(
         name="tree_census_1995",
         project_id="{{ var.value.gcp_project }}",
         location="us-central1-c",
-        cluster_name="new-york",
+        cluster_name="pubds-new-york",
         namespace="default",
         image_pull_policy="Always",
         image="{{ var.json.new_york.container_registry.run_csv_transform_kub_tree_census_1995 }}",
@@ -182,7 +182,7 @@ with DAG(
         task_id="delete_cluster",
         project_id="{{ var.value.gcp_project }}",
         location="us-central1-c",
-        name="new-york",
+        name="pubds-new-york",
     )
 
     (

--- a/datasets/new_york/pipelines/new_york/new_york_dag.py
+++ b/datasets/new_york/pipelines/new_york/new_york_dag.py
@@ -39,6 +39,7 @@ with DAG(
             "name": "new-york",
             "initial_node_count": 4,
             "network": "{{ var.value.vpc_network }}",
+            "ip_allocation_policy": {"cluster_ipv4_cidr_block": "/26"},
             "node_config": {
                 "machine_type": "e2-standard-16",
                 "oauth_scopes": [

--- a/datasets/new_york/pipelines/new_york/pipeline.yaml
+++ b/datasets/new_york/pipelines/new_york/pipeline.yaml
@@ -58,7 +58,7 @@ dag:
         cluster_name: new-york
         namespace: "default"
         image_pull_policy: "Always"
-        image: "{{ var.json.new_york.container_registry.ny_311_service_requests.run_csv_transform_kub }}"
+        image: "{{ var.json.new_york.container_registry.run_csv_transform_kub_ny_311_service_requests }}"
         env_vars:
           PIPELINE_NAME: "{{ var.json.new_york.ny_311_service_requests.pipeline_name }}"
           SOURCE_URL: "{{ var.json.new_york.ny_311_service_requests.source_url }}"
@@ -228,7 +228,7 @@ dag:
         cluster_name: new-york
         namespace: "default"
         image_pull_policy: "Always"
-        image: "{{ var.json.new_york.container_registry.citibike_stations.run_csv_transform_kub }}"
+        image: "{{ var.json.new_york.container_registry.run_csv_transform_kub_citibike_stations }}"
         env_vars:
           PIPELINE_NAME: "{{ var.json.new_york.citibike_stations.pipeline_name }}"
           SOURCE_URL_STATIONS_JSON: "{{ var.json.new_york.citibike_stations.source_url_stations }}"
@@ -369,7 +369,7 @@ dag:
         cluster_name: new-york
         namespace: "default"
         image_pull_policy: "Always"
-        image: "{{ var.json.new_york.container_registry.nypd_mv_collisions.run_csv_transform_kub }}"
+        image: "{{ var.json.new_york.container_registry.run_csv_transform_kub_nypd_mv_collisions }}"
         env_vars:
           PIPELINE_NAME: "{{ var.json.new_york.nypd_mv_collisions.pipeline_name }}"
           SOURCE_URL: "{{ var.json.new_york.nypd_mv_collisions.source_url }}"
@@ -514,7 +514,7 @@ dag:
         cluster_name: new-york
         namespace: "default"
         image_pull_policy: "Always"
-        image: "{{ var.json.new_york.container_registry.tree_census_1995.run_csv_transform_kub }}"
+        image: "{{ var.json.new_york.container_registry.run_csv_transform_kub_tree_census_1995 }}"
         env_vars:
           PIPELINE_NAME: "{{ var.json.new_york.tree_census_1995.pipeline_name }}"
           SOURCE_URL: "{{ var.json.new_york.tree_census_1995.source_url }}"

--- a/datasets/new_york/pipelines/new_york/pipeline.yaml
+++ b/datasets/new_york/pipelines/new_york/pipeline.yaml
@@ -39,7 +39,7 @@ dag:
         project_id: "{{ var.value.gcp_project }}"
         location: "us-central1-c"
         body:
-          name: new-york
+          name: pubds-new-york
           initial_node_count: 4
           network: "{{ var.value.vpc_network }}"
           ip_allocation_policy:
@@ -57,7 +57,7 @@ dag:
         name: "311_service_requests"
         project_id: "{{ var.value.gcp_project }}"
         location: "us-central1-c"
-        cluster_name: new-york
+        cluster_name: pubds-new-york
         namespace: "default"
         image_pull_policy: "Always"
         image: "{{ var.json.new_york.container_registry.run_csv_transform_kub_ny_311_service_requests }}"
@@ -227,7 +227,7 @@ dag:
         name: "citibike_stations"
         project_id: "{{ var.value.gcp_project }}"
         location: "us-central1-c"
-        cluster_name: new-york
+        cluster_name: pubds-new-york
         namespace: "default"
         image_pull_policy: "Always"
         image: "{{ var.json.new_york.container_registry.run_csv_transform_kub_citibike_stations }}"
@@ -368,7 +368,7 @@ dag:
         name: "nypd_mv_collisions"
         project_id: "{{ var.value.gcp_project }}"
         location: "us-central1-c"
-        cluster_name: new-york
+        cluster_name: pubds-new-york
         namespace: "default"
         image_pull_policy: "Always"
         image: "{{ var.json.new_york.container_registry.run_csv_transform_kub_nypd_mv_collisions }}"
@@ -513,7 +513,7 @@ dag:
         name: "tree_census_1995"
         project_id: "{{ var.value.gcp_project }}"
         location: "us-central1-c"
-        cluster_name: new-york
+        cluster_name: pubds-new-york
         namespace: "default"
         image_pull_policy: "Always"
         image: "{{ var.json.new_york.container_registry.run_csv_transform_kub_tree_census_1995 }}"
@@ -602,7 +602,7 @@ dag:
         task_id: "delete_cluster"
         project_id: "{{ var.value.gcp_project }}"
         location: "us-central1-c"
-        name: new-york
+        name: pubds-new-york
 
   graph_paths:
     - "create_cluster >> [transform_csv_nypd_mv_collisions, transform_csv_ny_citibike_stations, transform_csv_ny_tree_census_1995, transform_csv_ny_311_service_requests ] >> delete_cluster"

--- a/datasets/new_york/pipelines/new_york/pipeline.yaml
+++ b/datasets/new_york/pipelines/new_york/pipeline.yaml
@@ -42,6 +42,8 @@ dag:
           name: new-york
           initial_node_count: 4
           network: "{{ var.value.vpc_network }}"
+          ip_allocation_policy:
+            cluster_ipv4_cidr_block: "/26"
           node_config:
             machine_type: e2-standard-16
             oauth_scopes:


### PR DESCRIPTION
## Description

Resolution to issue pertaining to corrupted cluster happening when generating cluster name new-york.

## Checklist

- [ ] **(Required)** This pull request is appropriately labeled
- [ ] Please merge this pull request after it's approved

Use the sections below based on what's applicable to your PR and delete the rest:

### Data Onboarding
- [ ] I'm adding or editing a dataset
- [ ] The [Google Cloud Datasets team](mailto:cloud-datasets-onboarding@google.com) is aware of the proposed dataset
- [ ] I put all my code inside  `datasets/new_york` and nothing outside of that directory
