### PR TITLE
fix: Overwrite destination table for open_targets BQ copy operation

### DIFF
--- a/datasets/open_targets/pipelines/_images/copy_bq_datasets/script.py
+++ b/datasets/open_targets/pipelines/_images/copy_bq_datasets/script.py
@@ -126,6 +126,7 @@ def create_transfer_config(
         data_source_id="cross_region_copy",
         dataset_region="US",
         params={
+            "overwrite_destination_table": True,
             "source_project_id": source_project_id,
             "source_dataset_id": source_dataset_name,
         },


### PR DESCRIPTION
The `open_targets_*` datasets haven't been updated since launch. There was a misconfiguration on the BQ copy dataset operator where the overwrite option was set to `False`, thus not updating the public datasets. This PR fixes that.