### PR TITLE
feat: Add a note to the dataset and table descriptions

### DIFF
--- a/datasets/google_cloud_release_notes/infra/google_cloud_release_notes_dataset.tf
+++ b/datasets/google_cloud_release_notes/infra/google_cloud_release_notes_dataset.tf
@@ -18,7 +18,7 @@
 resource "google_bigquery_dataset" "google_cloud_release_notes" {
   dataset_id  = "google_cloud_release_notes"
   project     = var.project_id
-  description = "This dataset contains release notes for the majority of generally available Google Cloud products found on cloud.google.com. You can use this BigQuery public dataset to consume release notes programmatically across all products. HTML versions of release notes are available within each product\u0027s documentation and also in a filterable format at https://console.cloud.google.com/release-notes."
+  description = "This dataset contains release notes for the majority of generally available Google Cloud products found on cloud.google.com. You can use this BigQuery public dataset to consume release notes programmatically across all products. HTML versions of release notes are available within each product\u0027s documentation and also in a filterable format at https://console.cloud.google.com/release-notes. Note: The release notes in this dataset are delayed a few days compared to the HTML versions."
 }
 
 output "bigquery_dataset-google_cloud_release_notes-dataset_id" {

--- a/datasets/google_cloud_release_notes/pipelines/dataset.yaml
+++ b/datasets/google_cloud_release_notes/pipelines/dataset.yaml
@@ -22,4 +22,4 @@ dataset:
 resources:
   - type: bigquery_dataset
     dataset_id: google_cloud_release_notes
-    description: "This dataset contains release notes for the majority of generally available Google Cloud products found on cloud.google.com. You can use this BigQuery public dataset to consume release notes programmatically across all products. HTML versions of release notes are available within each product's documentation and also in a filterable format at https://console.cloud.google.com/release-notes."
+    description: "This dataset contains release notes for the majority of generally available Google Cloud products found on cloud.google.com. You can use this BigQuery public dataset to consume release notes programmatically across all products. HTML versions of release notes are available within each product's documentation and also in a filterable format at https://console.cloud.google.com/release-notes. Note: The release notes in this dataset are delayed a few days compared to the HTML versions."


### PR DESCRIPTION
The note explains that there is a delay from the time the release notes are published in the HTML versions until they are available in the `google_cloud_release_notes` dataset.

The note is required because there are user reports that indicate that users expect the release notes to be synchronized between the different locations. The note sets expectations accordingly.

## Description

Notes:
* If you are adding or editing a dataset, please specify the dataset folder involved, e.g. `datasets/google_trends`.  
  The dataset folder involved is `datasets/google_cloud_release_notes`.
* If you are an external contributor, please contact the [Google Cloud Datasets team](mailto:cloud-datasets-onboarding@google.com) for your proposed dataset or feature.  
  Not an external contributor. I'm part of the [Google Cloud Platform][0] organization on GitHub.
* If you are adding or editing a dataset, please do it one dataset at a time. Have all the code changes inside a single  `datasets/<DATASET_NAME>` folder.  
  This pull request only updates the Google Cloud Release Notes dataset in the `datasets/google_cloud_release_notes` folder.

[0]: https://github.com/GoogleCloudPlatform