### PR TITLE
Fix: Migration Changes for Google Cloud Release Notes dag

### DIFF
--- a/datasets/google_cloud_release_notes/pipelines/release_notes/pipeline.yaml
+++ b/datasets/google_cloud_release_notes/pipelines/release_notes/pipeline.yaml
@@ -32,13 +32,31 @@ dag:
     default_view: graph
 
   tasks:
-    - operator: "KubernetesPodOperator"
+    - operator: "GKECreateClusterOperator"
+      args:
+        task_id: "create_cluster"
+        project_id: "{{ var.value.gcp_project }}"
+        location: "us-central1-c"
+        body:
+          name: pdp-google-cloud-release-notes
+          initial_node_count: 2
+          network: "{{ var.value.vpc_network }}"
+          node_config:
+            machine_type: e2-standard-16
+            oauth_scopes:
+              - https://www.googleapis.com/auth/devstorage.read_write
+              - https://www.googleapis.com/auth/cloud-platform
+
+    - operator: "GKEStartPodOperator"
       description: "Copy GCP release notes dataset"
       args:
         task_id: "copy_bq_dataset"
+        startup_timeout_seconds: 1000
         name: "copy_bq_dataset"
-        namespace: "composer"
-        service_account_name: "datasets"
+        namespace: "default"
+        project_id: "{{ var.value.gcp_project }}"
+        location: "us-central1-c"
+        cluster_name: pdp-google-cloud-release-notes
         image_pull_policy: "Always"
         image: "{{ var.json.google_cloud_release_notes.container_registry.copy_bq_dataset }}"
         env_vars:
@@ -47,9 +65,20 @@ dag:
           TARGET_PROJECT_ID: "{{ var.value.gcp_project }}"
           TARGET_BQ_DATASET: google_cloud_release_notes
           SERVICE_ACCOUNT: "{{ var.json.google_cloud_release_notes.service_account }}"
-        resources:
-          request_memory: "128M"
-          request_cpu: "200m"
+        container_resources:
+          memory:
+            request: "32Gi"
+          cpu:
+            request: "2"
+          ephemeral-storage:
+            request: "10Gi"
+
+    - operator: "GKEDeleteClusterOperator"
+      args:
+        task_id: "delete_cluster"
+        project_id: "{{ var.value.gcp_project }}"
+        location: "us-central1-c"
+        name: pdp-google-cloud-release-notes
 
   graph_paths:
-    - "copy_bq_dataset"
+    - "create_cluster >> copy_bq_dataset >> delete_cluster"


### PR DESCRIPTION
## Description
Migration Changes for "Google Cloud Release Notes" dag

Notes:
* We have made changes to fix the migration of "Google Cloud Release Notes" dag. Have all the code changes inside a single  `datasets/google_cloud_release_notes` folder.
