### PR TITLE
Fix: Scheduled time change from 12 AM UTC to 2 AM UTC for google_trends DAG

### DIFF
--- a/datasets/google_trends/pipelines/copy_trends_data/copy_trends_data_dag.py
+++ b/datasets/google_trends/pipelines/copy_trends_data/copy_trends_data_dag.py
@@ -27,7 +27,7 @@ with DAG(
     dag_id="google_trends.copy_trends_data",
     default_args=default_args,
     max_active_runs=1,
-    schedule_interval="@daily",
+    schedule_interval="0 2 * * *",
     catchup=False,
     default_view="graph",
 ) as dag:

--- a/datasets/google_trends/pipelines/copy_trends_data/pipeline.yaml
+++ b/datasets/google_trends/pipelines/copy_trends_data/pipeline.yaml
@@ -24,7 +24,7 @@ dag:
       depends_on_past: False
       start_date: '2022-03-22'
     max_active_runs: 1
-    schedule_interval: "@daily"
+    schedule_interval: "0 2 * * *"
     catchup: False
     default_view: graph
 


### PR DESCRIPTION
Scheduled time change from 12 AM UTC to 2 AM UTC for google_trends DAG

This will schedule the DAG run time from @daily at 12 AM UTC to 2 AM UTC for  google_trends DAG
