### PR TITLE
Fix: Made the changes to update bq bls datasets for cpsaat18 tables

### DIFF
--- a/datasets/bls/pipelines/cpsaat18/cpsaat18_dag.py
+++ b/datasets/bls/pipelines/cpsaat18/cpsaat18_dag.py
@@ -36,7 +36,7 @@ with DAG(
     load_csv_to_bq = gcs_to_bigquery.GCSToBigQueryOperator(
         task_id="load_csv_to_bq",
         bucket="{{ var.json.bls.source_bucket }}",
-        source_objects=["cpsaat18/2021.csv"],
+        source_objects=["cpsaat18/2023.csv"],
         source_format="CSV",
         destination_project_dataset_table="bls.cpsaat18",
         skip_leading_rows=1,

--- a/datasets/bls/pipelines/cpsaat18/pipeline.yaml
+++ b/datasets/bls/pipelines/cpsaat18/pipeline.yaml
@@ -37,7 +37,7 @@ dag:
       args:
         task_id: "load_csv_to_bq"
         bucket: "{{ var.json.bls.source_bucket }}"
-        source_objects: ["cpsaat18/2021.csv"]
+        source_objects: ["cpsaat18/2023.csv"]
         source_format: "CSV"
         destination_project_dataset_table: "bls.cpsaat18"
         skip_leading_rows: 1


### PR DESCRIPTION
Made the changes to update bq bls datasets for cpsaat18 tables of the DAG bls.cpsaat18

Notes:
The source file "2023.csv" was used to update the BLS datasets for cpsaat18; the necessary code changes have been implemented.
This implementation will update the bq bls datasets with data from the latest available year.


