### PR TITLE
Fix: The DAG task noaa_gsod_by_year responsible for updating the noaa_gsod dataset, has been removed due to the deprecation of GSOD.

### DIFF
--- a/datasets/noaa/pipelines/noaa/noaa_dag.py
+++ b/datasets/noaa/pipelines/noaa/noaa_dag.py
@@ -784,42 +784,6 @@ with DAG(
             "REORDER_HEADERS_LIST": '[\n  "dataset_name",\n  "platform_id",\n  "orbital_slot",\n  "timeline_id",\n  "scene_id",\n  "band_id",\n  "time_coverage_start",\n  "time_coverage_end",\n  "date_created",\n  "geospatial_westbound_longitude",\n  "geospatial_northbound_latitude",\n  "geospatial_eastbound_longitude",\n  "geospatial_southbound_latitude",\n  "nominal_satellite_subpoint_lon",\n  "valid_pixel_count",\n  "missing_pixel_count",\n  "saturated_pixel_count",\n  "undersaturated_pixel_count",\n  "min_radiance_value_of_valid_pixels",\n  "max_radiance_value_of_valid_pixels",\n  "mean_radiance_value_of_valid_pixels",\n  "std_dev_radiance_value_of_valid_pixels",\n  "percent_uncorrectable_l0_errors",\n  "total_size",\n  "base_url"\n]',
         },
     )
-
-    # Run NOAA load processes - GSOD By Year
-    noaa_gsod_by_year = kubernetes_engine.GKEStartPodOperator(
-        task_id="noaa_gsod_by_year",
-        name="noaa.gsod_by_year",
-        project_id="{{ var.value.gcp_project }}",
-        location="us-central1-c",
-        cluster_name="noaa",
-        namespace="default",
-        image_pull_policy="Always",
-        image="{{ var.json.noaa.container_registry.run_csv_transform_kub }}",
-        env_vars={
-            "PIPELINE_NAME": "NOAA GSOD By Year",
-            "START_YEAR": "1929",
-            "SOURCE_URL": '{\n  "noaa_gsod_by_year": "https://www.ncei.noaa.gov/data/global-summary-of-the-day/access/"\n}',
-            "SOURCE_FILE": "files/data_gsod_.csv",
-            "TARGET_FILE": "files/data_output_gsod_.csv",
-            "CHUNKSIZE": "100000",
-            "PROJECT_ID": "{{ var.value.gcp_project }}",
-            "DATASET_ID": "noaa_gsod",
-            "TABLE_ID": "gsod",
-            "TARGET_GCS_BUCKET": "{{ var.value.composer_bucket }}",
-            "TARGET_GCS_PATH": "data/noaa/gsod_by_year/data_output.csv",
-            "SCHEMA_PATH": "data/noaa/schema/noaa_gsod_by_year_schema.json",
-            "DROP_DEST_TABLE": "N",
-            "INPUT_FIELD_DELIMITER": ",",
-            "FULL_DATA_LOAD": "N",
-            "REMOVE_SOURCE_FILE": "N",
-            "DELETE_TARGET_FILE": "Y",
-            "NUMBER_OF_HEADER_ROWS": "1",
-            "INPUT_CSV_HEADERS": '[\n  "STATION",\n  "DATE",\n  "LATITUDE",\n  "LONGITUDE",\n  "ELEVATION",\n  "NAME",\n  "TEMP",\n  "TEMP_ATTRIBUTES",\n  "DEWP",\n  "DEWP_ATTRIBUTES",\n  "SLP",\n  "SLP_ATTRIBUTES",\n  "STP",\n  "STP_ATTRIBUTES",\n  "VISIB",\n  "VISIB_ATTRIBUTES",\n  "WDSP",\n  "WDSP_ATTRIBUTES",\n  "MXSPD",\n  "GUST",\n  "MAX",\n  "MAX_ATTRIBUTES",\n  "MIN",\n  "MIN_ATTRIBUTES",\n  "PRCP",\n  "PRCP_ATTRIBUTES",\n  "SNDP",\n  "FRSHTT"\n]',
-            "RENAME_HEADERS_LIST": '{\n  "TEMP": "temp",\n  "TEMP_ATTRIBUTES": "count_temp",\n  "DEWP": "dewp",\n  "DEWP_ATTRIBUTES": "count_dewp",\n  "SLP": "slp",\n  "SLP_ATTRIBUTES": "count_slp",\n  "STP": "stp",\n  "STP_ATTRIBUTES": "count_stp",\n  "VISIB": "visib",\n  "VISIB_ATTRIBUTES": "count_visib",\n  "WDSP": "wdsp",\n  "WDSP_ATTRIBUTES": "count_wdsp",\n  "MXSPD": "mxspd",\n  "GUST": "gust",\n  "MAX": "max",\n  "MAX_ATTRIBUTES": "flag_max",\n  "MIN": "min",\n  "MIN_ATTRIBUTES": "flag_min",\n  "PRCP": "prcp",\n  "PRCP_ATTRIBUTES": "flag_prcp",\n  "SNDP": "sndp",\n  "DATE": "date"\n}',
-            "TRIM_WHITESPACE_LIST": '[\n  "stn",\n  "wban",\n  "year",\n  "mo",\n  "da",\n  "date",\n  "temp",\n  "count_temp",\n  "dewp",\n  "count_dewp",\n  "slp",\n  "count_slp",\n  "stp",\n  "count_stp",\n  "visib",\n  "count_visib",\n  "wdsp",\n  "count_wdsp",\n  "mxspd",\n  "gust",\n  "max",\n  "flag_max",\n  "min",\n  "flag_min",\n  "prcp",\n  "flag_prcp",\n  "sndp",\n  "fog",\n  "rain_drizzle",\n  "snow_ice_pellets",\n  "hail",\n  "thunder",\n  "tornado_funnel_cloud"\n]',
-            "REORDER_HEADERS_LIST": '[\n  "stn",\n  "wban",\n  "date",\n  "year",\n  "mo",\n  "da",\n  "temp",\n  "count_temp",\n  "dewp",\n  "count_dewp",\n  "slp",\n  "count_slp",\n  "stp",\n  "count_stp",\n  "visib",\n  "count_visib",\n  "wdsp",\n  "count_wdsp",\n  "mxspd",\n  "gust",\n  "max",\n  "flag_max",\n  "min",\n  "flag_min",\n  "prcp",\n  "flag_prcp",\n  "sndp",\n  "fog",\n  "rain_drizzle",\n  "snow_ice_pellets",\n  "hail",\n  "thunder",\n  "tornado_funnel_cloud"\n]',
-        },
-    )
     delete_cluster = kubernetes_engine.GKEDeleteClusterOperator(
         task_id="delete_cluster",
         project_id="{{ var.value.gcp_project }}",
@@ -852,6 +816,5 @@ with DAG(
         >> lightning_strikes_by_year
         >> noaa_ghcn_m
         >> storms_database_by_year
-        >> noaa_gsod_by_year
         >> delete_cluster
     )

--- a/datasets/noaa/pipelines/noaa/pipeline.yaml
+++ b/datasets/noaa/pipelines/noaa/pipeline.yaml
@@ -2824,167 +2824,167 @@ dag:
               "base_url"
             ]
 
-    - operator: "GKEStartPodOperator"
-      description: "Run NOAA load processes - GSOD By Year"
-      args:
-        task_id: "noaa_gsod_by_year"
-        name: "noaa.gsod_by_year"
-        project_id: "{{ var.value.gcp_project }}"
-        location: "us-central1-c"
-        cluster_name: noaa
-        namespace: "default"
-        image_pull_policy: "Always"
-        image: "{{ var.json.noaa.container_registry.run_csv_transform_kub }}"
-        env_vars:
-          PIPELINE_NAME: "NOAA GSOD By Year"
-          START_YEAR: "1929"
-          SOURCE_URL: >-
-            {
-              "noaa_gsod_by_year": "https://www.ncei.noaa.gov/data/global-summary-of-the-day/access/"
-            }
-          SOURCE_FILE: "files/data_gsod_.csv"
-          TARGET_FILE: "files/data_output_gsod_.csv"
-          CHUNKSIZE: "100000"
-          PROJECT_ID: "{{ var.value.gcp_project }}"
-          DATASET_ID: "noaa_gsod"
-          TABLE_ID: "gsod"
-          TARGET_GCS_BUCKET: "{{ var.value.composer_bucket }}"
-          TARGET_GCS_PATH: "data/noaa/gsod_by_year/data_output.csv"
-          SCHEMA_PATH: "data/noaa/schema/noaa_gsod_by_year_schema.json"
-          DROP_DEST_TABLE: "N"
-          INPUT_FIELD_DELIMITER: ","
-          FULL_DATA_LOAD: "N"
-          REMOVE_SOURCE_FILE: "N"
-          DELETE_TARGET_FILE: "Y"
-          NUMBER_OF_HEADER_ROWS: "1"
-          INPUT_CSV_HEADERS: >-
-            [
-              "STATION",
-              "DATE",
-              "LATITUDE",
-              "LONGITUDE",
-              "ELEVATION",
-              "NAME",
-              "TEMP",
-              "TEMP_ATTRIBUTES",
-              "DEWP",
-              "DEWP_ATTRIBUTES",
-              "SLP",
-              "SLP_ATTRIBUTES",
-              "STP",
-              "STP_ATTRIBUTES",
-              "VISIB",
-              "VISIB_ATTRIBUTES",
-              "WDSP",
-              "WDSP_ATTRIBUTES",
-              "MXSPD",
-              "GUST",
-              "MAX",
-              "MAX_ATTRIBUTES",
-              "MIN",
-              "MIN_ATTRIBUTES",
-              "PRCP",
-              "PRCP_ATTRIBUTES",
-              "SNDP",
-              "FRSHTT"
-            ]
-          RENAME_HEADERS_LIST: >-
-            {
-              "TEMP": "temp",
-              "TEMP_ATTRIBUTES": "count_temp",
-              "DEWP": "dewp",
-              "DEWP_ATTRIBUTES": "count_dewp",
-              "SLP": "slp",
-              "SLP_ATTRIBUTES": "count_slp",
-              "STP": "stp",
-              "STP_ATTRIBUTES": "count_stp",
-              "VISIB": "visib",
-              "VISIB_ATTRIBUTES": "count_visib",
-              "WDSP": "wdsp",
-              "WDSP_ATTRIBUTES": "count_wdsp",
-              "MXSPD": "mxspd",
-              "GUST": "gust",
-              "MAX": "max",
-              "MAX_ATTRIBUTES": "flag_max",
-              "MIN": "min",
-              "MIN_ATTRIBUTES": "flag_min",
-              "PRCP": "prcp",
-              "PRCP_ATTRIBUTES": "flag_prcp",
-              "SNDP": "sndp",
-              "DATE": "date"
-            }
-          TRIM_WHITESPACE_LIST: >-
-            [
-              "stn",
-              "wban",
-              "year",
-              "mo",
-              "da",
-              "date",
-              "temp",
-              "count_temp",
-              "dewp",
-              "count_dewp",
-              "slp",
-              "count_slp",
-              "stp",
-              "count_stp",
-              "visib",
-              "count_visib",
-              "wdsp",
-              "count_wdsp",
-              "mxspd",
-              "gust",
-              "max",
-              "flag_max",
-              "min",
-              "flag_min",
-              "prcp",
-              "flag_prcp",
-              "sndp",
-              "fog",
-              "rain_drizzle",
-              "snow_ice_pellets",
-              "hail",
-              "thunder",
-              "tornado_funnel_cloud"
-            ]
-          REORDER_HEADERS_LIST: >-
-            [
-              "stn",
-              "wban",
-              "date",
-              "year",
-              "mo",
-              "da",
-              "temp",
-              "count_temp",
-              "dewp",
-              "count_dewp",
-              "slp",
-              "count_slp",
-              "stp",
-              "count_stp",
-              "visib",
-              "count_visib",
-              "wdsp",
-              "count_wdsp",
-              "mxspd",
-              "gust",
-              "max",
-              "flag_max",
-              "min",
-              "flag_min",
-              "prcp",
-              "flag_prcp",
-              "sndp",
-              "fog",
-              "rain_drizzle",
-              "snow_ice_pellets",
-              "hail",
-              "thunder",
-              "tornado_funnel_cloud"
-            ]
+    # - operator: "GKEStartPodOperator"
+    #   description: "Run NOAA load processes - GSOD By Year"
+    #   args:
+    #     task_id: "noaa_gsod_by_year"
+    #     name: "noaa.gsod_by_year"
+    #     project_id: "{{ var.value.gcp_project }}"
+    #     location: "us-central1-c"
+    #     cluster_name: noaa
+    #     namespace: "default"
+    #     image_pull_policy: "Always"
+    #     image: "{{ var.json.noaa.container_registry.run_csv_transform_kub }}"
+    #     env_vars:
+    #       PIPELINE_NAME: "NOAA GSOD By Year"
+    #       START_YEAR: "1929"
+    #       SOURCE_URL: >-
+    #         {
+    #           "noaa_gsod_by_year": "https://www.ncei.noaa.gov/data/global-summary-of-the-day/access/"
+    #         }
+    #       SOURCE_FILE: "files/data_gsod_.csv"
+    #       TARGET_FILE: "files/data_output_gsod_.csv"
+    #       CHUNKSIZE: "100000"
+    #       PROJECT_ID: "{{ var.value.gcp_project }}"
+    #       DATASET_ID: "noaa_gsod"
+    #       TABLE_ID: "gsod"
+    #       TARGET_GCS_BUCKET: "{{ var.value.composer_bucket }}"
+    #       TARGET_GCS_PATH: "data/noaa/gsod_by_year/data_output.csv"
+    #       SCHEMA_PATH: "data/noaa/schema/noaa_gsod_by_year_schema.json"
+    #       DROP_DEST_TABLE: "N"
+    #       INPUT_FIELD_DELIMITER: ","
+    #       FULL_DATA_LOAD: "N"
+    #       REMOVE_SOURCE_FILE: "N"
+    #       DELETE_TARGET_FILE: "Y"
+    #       NUMBER_OF_HEADER_ROWS: "1"
+    #       INPUT_CSV_HEADERS: >-
+    #         [
+    #           "STATION",
+    #           "DATE",
+    #           "LATITUDE",
+    #           "LONGITUDE",
+    #           "ELEVATION",
+    #           "NAME",
+    #           "TEMP",
+    #           "TEMP_ATTRIBUTES",
+    #           "DEWP",
+    #           "DEWP_ATTRIBUTES",
+    #           "SLP",
+    #           "SLP_ATTRIBUTES",
+    #           "STP",
+    #           "STP_ATTRIBUTES",
+    #           "VISIB",
+    #           "VISIB_ATTRIBUTES",
+    #           "WDSP",
+    #           "WDSP_ATTRIBUTES",
+    #           "MXSPD",
+    #           "GUST",
+    #           "MAX",
+    #           "MAX_ATTRIBUTES",
+    #           "MIN",
+    #           "MIN_ATTRIBUTES",
+    #           "PRCP",
+    #           "PRCP_ATTRIBUTES",
+    #           "SNDP",
+    #           "FRSHTT"
+    #         ]
+    #       RENAME_HEADERS_LIST: >-
+    #         {
+    #           "TEMP": "temp",
+    #           "TEMP_ATTRIBUTES": "count_temp",
+    #           "DEWP": "dewp",
+    #           "DEWP_ATTRIBUTES": "count_dewp",
+    #           "SLP": "slp",
+    #           "SLP_ATTRIBUTES": "count_slp",
+    #           "STP": "stp",
+    #           "STP_ATTRIBUTES": "count_stp",
+    #           "VISIB": "visib",
+    #           "VISIB_ATTRIBUTES": "count_visib",
+    #           "WDSP": "wdsp",
+    #           "WDSP_ATTRIBUTES": "count_wdsp",
+    #           "MXSPD": "mxspd",
+    #           "GUST": "gust",
+    #           "MAX": "max",
+    #           "MAX_ATTRIBUTES": "flag_max",
+    #           "MIN": "min",
+    #           "MIN_ATTRIBUTES": "flag_min",
+    #           "PRCP": "prcp",
+    #           "PRCP_ATTRIBUTES": "flag_prcp",
+    #           "SNDP": "sndp",
+    #           "DATE": "date"
+    #         }
+    #       TRIM_WHITESPACE_LIST: >-
+    #         [
+    #           "stn",
+    #           "wban",
+    #           "year",
+    #           "mo",
+    #           "da",
+    #           "date",
+    #           "temp",
+    #           "count_temp",
+    #           "dewp",
+    #           "count_dewp",
+    #           "slp",
+    #           "count_slp",
+    #           "stp",
+    #           "count_stp",
+    #           "visib",
+    #           "count_visib",
+    #           "wdsp",
+    #           "count_wdsp",
+    #           "mxspd",
+    #           "gust",
+    #           "max",
+    #           "flag_max",
+    #           "min",
+    #           "flag_min",
+    #           "prcp",
+    #           "flag_prcp",
+    #           "sndp",
+    #           "fog",
+    #           "rain_drizzle",
+    #           "snow_ice_pellets",
+    #           "hail",
+    #           "thunder",
+    #           "tornado_funnel_cloud"
+    #         ]
+    #       REORDER_HEADERS_LIST: >-
+    #         [
+    #           "stn",
+    #           "wban",
+    #           "date",
+    #           "year",
+    #           "mo",
+    #           "da",
+    #           "temp",
+    #           "count_temp",
+    #           "dewp",
+    #           "count_dewp",
+    #           "slp",
+    #           "count_slp",
+    #           "stp",
+    #           "count_stp",
+    #           "visib",
+    #           "count_visib",
+    #           "wdsp",
+    #           "count_wdsp",
+    #           "mxspd",
+    #           "gust",
+    #           "max",
+    #           "flag_max",
+    #           "min",
+    #           "flag_min",
+    #           "prcp",
+    #           "flag_prcp",
+    #           "sndp",
+    #           "fog",
+    #           "rain_drizzle",
+    #           "snow_ice_pellets",
+    #           "hail",
+    #           "thunder",
+    #           "tornado_funnel_cloud"
+    #         ]
     - operator: "GKEDeleteClusterOperator"
       args:
         task_id: "delete_cluster"
@@ -2993,4 +2993,4 @@ dag:
         name: noaa
 
   graph_paths:
-    - "create_cluster >> [ ghcnd_inventory, spc_hail, spc_wind, spc_tornado, ghcnd_states, ghcnd_stations, gsod_stations, ghcnd_countries, noaa_goes16_mcmip, noaa_goes16_cmip, noaa_goes16_glm, noaa_goes16_radiance, noaa_goes17_mcmip, noaa_goes17_cmip, noaa_goes17_glm, noaa_goes17_radiance] >> ghcnd_hurricanes >> ghcnd_by_year >> lightning_strikes_by_year >> noaa_ghcn_m  >> storms_database_by_year >> noaa_gsod_by_year >> delete_cluster"
+    - "create_cluster >> [ ghcnd_inventory, spc_hail, spc_wind, spc_tornado, ghcnd_states, ghcnd_stations, gsod_stations, ghcnd_countries, noaa_goes16_mcmip, noaa_goes16_cmip, noaa_goes16_glm, noaa_goes16_radiance, noaa_goes17_mcmip, noaa_goes17_cmip, noaa_goes17_glm, noaa_goes17_radiance] >> ghcnd_hurricanes >> ghcnd_by_year >> lightning_strikes_by_year >> noaa_ghcn_m  >> storms_database_by_year >> delete_cluster"


### PR DESCRIPTION
fix:  Removed DAG task noaa_gsod_by_year responsible for updating the noaa_gsod dataset due to the depreciation of GSOD.

Notes:
We have removed the DAG task in  `datasets/noaa`. 