### PR TITLE
docs: Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**DEPRECATED: this repository is not accepting new PRs**
+
 # Google Cloud Datasets: Data Pipelines and Documentation Set
 
 ![public-datasets-pipelines](https://github.com/GoogleCloudPlatform/public-datasets-pipelines/blob/main/images/architecture.png)


### PR DESCRIPTION
docs: Add deprecation notice to README

Indicates that the repository is no longer accepting new PRs to reduce maintenance overhead.